### PR TITLE
Prototype to add config mediaType and annotation support to push

### DIFF
--- a/cmd/oras/push.go
+++ b/cmd/oras/push.go
@@ -16,9 +16,11 @@ type pushOptions struct {
 	targetRef string
 	fileRefs  []string
 
-	debug    bool
-	username string
-	password string
+	configMediaType   string
+	configAnnotations map[string]string
+	debug             bool
+	username          string
+	password          string
 }
 
 func pushCmd() *cobra.Command {
@@ -37,7 +39,7 @@ Example - Pull file "hi.txt" with the custom "application/vnd.me.hi" media type:
 Example - Push multiple files with different media types:
   oras push localhost:5000/hello:latest hi.txt:application/vnd.me.hi bye.txt:application/vnd.me.bye
 `,
-		Args:  cobra.MinimumNArgs(2),
+		Args: cobra.MinimumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.targetRef = args[0]
 			opts.fileRefs = args[1:]
@@ -46,6 +48,8 @@ Example - Push multiple files with different media types:
 	}
 
 	cmd.Flags().BoolVarP(&opts.debug, "debug", "d", false, "debug mode")
+	cmd.Flags().StringVarP(&opts.configMediaType, "type", "t", ocispec.MediaTypeImageConfig, "configuration descriptor media type")
+	cmd.Flags().StringToStringVarP(&opts.configAnnotations, "annotation", "a", nil, "annotations for the config descriptor")
 	cmd.Flags().StringVarP(&opts.username, "username", "u", "", "registry username")
 	cmd.Flags().StringVarP(&opts.password, "password", "p", "", "registry password")
 	return cmd
@@ -76,5 +80,5 @@ func runPush(opts pushOptions) error {
 		files = append(files, file)
 	}
 
-	return oras.Push(context.Background(), resolver, opts.targetRef, store, files)
+	return oras.Push(context.Background(), resolver, opts.targetRef, store, opts.configMediaType, opts.configAnnotations, files)
 }


### PR DESCRIPTION
This fixes #50 

This is just quick prototype on ORAS to support mediaTypes in config blobs so that registries can determine the artifacts appropriately. 

How do you push config media types ? 

```bash
$ ./oras push localhost:5000/oras:latest -t application/vnd.test -a a=1 -a b=2  ./oras
```
Produces the following manifest 
```
{
  "schemaVersion": 2,
  "config": {
    "mediaType": "application/vnd.test",
    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
    "size": 2,
    "annotations": {
      "a": "1",
      "b": "2"
    }
  },
  "layers": [
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar",
      "digest": "sha256:066fed7ff6d005eea332f9ab7da7e815c5c41a6b6c1c3b60c1c497eb630d1f19",
      "size": 11035464,
      "annotations": {
        "org.opencontainers.image.title": "./oras"
      }
    }
  ]
}
```
/cc @shizhMSFT 

## Pending items 

- [ ] the public push method takes too many arguments and potentially needs refactoring, maybe through a stateful model or take a [Manifest](https://github.com/opencontainers/image-spec/blob/master/specs-go/v1/manifest.go#L20) itself .
- [ ]  If we are supporting root media type then we might want to reserve -t for that 
- [ ] Need to fix tests 
- [ ] Need to consider passing in config blob as a file as well and not just use `{}`
