### PR TITLE
Directory Support

### DIFF
--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -70,7 +70,7 @@ func runPull(opts pullOptions) error {
 	if opts.allowAllMediaTypes {
 		opts.allowedMediaTypes = nil
 	} else if len(opts.allowedMediaTypes) == 0 {
-		opts.allowedMediaTypes = []string{content.DefaultBlobMediaType}
+		opts.allowedMediaTypes = []string{content.DefaultBlobMediaType, content.DefaultBlobDirMediaType}
 	}
 
 	resolver := newResolver(opts.username, opts.password, opts.configs...)

--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -75,6 +75,7 @@ func runPull(opts pullOptions) error {
 
 	resolver := newResolver(opts.username, opts.password, opts.configs...)
 	store := content.NewFileStore(opts.output)
+	defer store.Close()
 	store.DisableOverwrite = opts.keepOldFiles
 	store.AllowPathTraversalOnWrite = opts.pathTraversal
 	files, err := oras.Pull(context.Background(), resolver, opts.targetRef, store, opts.allowedMediaTypes...)

--- a/cmd/oras/push.go
+++ b/cmd/oras/push.go
@@ -79,6 +79,7 @@ func runPush(opts pushOptions) error {
 		store       = content.NewFileStore("")
 		pushOpts    []oras.PushOpt
 	)
+	defer store.Close()
 	if opts.manifestAnnotations != "" {
 		if err := decodeJSON(opts.manifestAnnotations, &annotations); err != nil {
 			return err

--- a/pkg/content/consts.go
+++ b/pkg/content/consts.go
@@ -2,5 +2,19 @@ package content
 
 import ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
-// DefaultBlobMediaType specifies the default blob media type
-const DefaultBlobMediaType = ocispec.MediaTypeImageLayer
+const (
+	// DefaultBlobMediaType specifies the default blob media type
+	DefaultBlobMediaType = ocispec.MediaTypeImageLayer
+	// DefaultBlobDirMediaType specifies the default blob directory media type
+	DefaultBlobDirMediaType = ocispec.MediaTypeImageLayerGzip
+)
+
+const (
+	// TempFilePattern specifies the pattern to create temporary files
+	TempFilePattern = "oras"
+)
+
+const (
+	// AnnotationDigest is the annotation key for the digest of the uncompressed content
+	AnnotationDigest = "io.deis.oras.content.digest"
+)

--- a/pkg/content/consts.go
+++ b/pkg/content/consts.go
@@ -17,4 +17,6 @@ const (
 const (
 	// AnnotationDigest is the annotation key for the digest of the uncompressed content
 	AnnotationDigest = "io.deis.oras.content.digest"
+	// AnnotationUnpack is the annotation key for indication of unpacking
+	AnnotationUnpack = "io.deis.oras.content.unpack"
 )

--- a/pkg/content/file.go
+++ b/pkg/content/file.go
@@ -110,7 +110,7 @@ func (s *FileStore) descFromDir(name, mediaType, root string) (ocispec.Descripto
 	zw := gzip.NewWriter(io.MultiWriter(file, digester.Hash()))
 	defer zw.Close()
 	tarDigester := digest.Canonical.Digester()
-	if err := TarDirectory(root, name, io.MultiWriter(zw, tarDigester.Hash())); err != nil {
+	if err := tarDirectory(root, name, io.MultiWriter(zw, tarDigester.Hash())); err != nil {
 		return ocispec.Descriptor{}, err
 	}
 

--- a/pkg/content/file.go
+++ b/pkg/content/file.go
@@ -136,6 +136,7 @@ func (s *FileStore) descFromDir(name, mediaType, root string) (ocispec.Descripto
 		Size:      info.Size(),
 		Annotations: map[string]string{
 			AnnotationDigest: tarDigester.Digest().String(),
+			AnnotationUnpack: "true",
 		},
 	}, nil
 }

--- a/pkg/content/utils.go
+++ b/pkg/content/utils.go
@@ -93,12 +93,14 @@ func extractTarDirectory(root, prefix string, r io.Reader) error {
 
 		// Name check
 		name := header.Name
-		if rel, err := filepath.Rel(prefix, name); err != nil {
+		path, err := filepath.Rel(prefix, name)
+		if err != nil {
 			return err
-		} else if filepath.HasPrefix(rel, "../") {
+		}
+		if filepath.HasPrefix(path, "../") {
 			return fmt.Errorf("%q does not have prefix %q", name, prefix)
 		}
-		path := filepath.Join(root, name)
+		path = filepath.Join(root, path)
 
 		// Create content
 		switch header.Typeflag {

--- a/pkg/content/utils.go
+++ b/pkg/content/utils.go
@@ -23,13 +23,13 @@ func TarDirectory(root, prefix string, w io.Writer) error {
 	defer tw.Close()
 	if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return errors.Wrap(err, path)
+			return err
 		}
 
 		// Rename path
 		name, err := filepath.Rel(root, path)
 		if err != nil {
-			return errors.Wrap(err, path)
+			return err
 		}
 		name = filepath.Join(prefix, name)
 		name = filepath.ToSlash(name)
@@ -38,8 +38,8 @@ func TarDirectory(root, prefix string, w io.Writer) error {
 		var link string
 		mode := info.Mode()
 		if mode&os.ModeSymlink != 0 {
-			if link, err = os.Readlink(link); err != nil {
-				return errors.Wrap(err, path)
+			if link, err = os.Readlink(path); err != nil {
+				return err
 			}
 		}
 		header, err := tar.FileInfoHeader(info, link)
@@ -59,7 +59,7 @@ func TarDirectory(root, prefix string, w io.Writer) error {
 		if mode.IsRegular() {
 			file, err := os.Open(path)
 			if err != nil {
-				return errors.Wrap(err, path)
+				return err
 			}
 			if _, err := io.Copy(tw, file); err != nil {
 				return errors.Wrap(err, path)

--- a/pkg/content/utils.go
+++ b/pkg/content/utils.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -97,7 +98,7 @@ func extractTarDirectory(root, prefix string, r io.Reader) error {
 		if err != nil {
 			return err
 		}
-		if filepath.HasPrefix(path, "../") {
+		if strings.HasPrefix(path, "../") {
 			return fmt.Errorf("%q does not have prefix %q", name, prefix)
 		}
 		path = filepath.Join(root, path)

--- a/pkg/content/utils.go
+++ b/pkg/content/utils.go
@@ -39,12 +39,12 @@ func TarDirectory(root, prefix string, w io.Writer) error {
 		mode := info.Mode()
 		if mode&os.ModeSymlink != 0 {
 			if link, err = os.Readlink(link); err != nil {
-				return err
+				return errors.Wrap(err, path)
 			}
 		}
 		header, err := tar.FileInfoHeader(info, link)
 		if err != nil {
-			return err
+			return errors.Wrap(err, path)
 		}
 		header.Name = name
 		header.Uid = 0
@@ -54,7 +54,7 @@ func TarDirectory(root, prefix string, w io.Writer) error {
 
 		// Write file
 		if err := tw.WriteHeader(header); err != nil {
-			return err
+			return errors.Wrap(err, "tar")
 		}
 		if mode.IsRegular() {
 			file, err := os.Open(path)

--- a/pkg/content/utils.go
+++ b/pkg/content/utils.go
@@ -1,9 +1,74 @@
 package content
 
-import ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+import (
+	"archive/tar"
+	"io"
+	"os"
+	"path/filepath"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
 
 // ResolveName resolves name from descriptor
 func ResolveName(desc ocispec.Descriptor) (string, bool) {
 	name, ok := desc.Annotations[ocispec.AnnotationTitle]
 	return name, ok
+}
+
+// TarDirectory walks the directory specified by path, and tar those files with a new
+// path prefix.
+func TarDirectory(root, prefix string, w io.Writer) error {
+	tw := tar.NewWriter(w)
+	defer tw.Close()
+	if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return errors.Wrap(err, path)
+		}
+
+		// Rename path
+		name, err := filepath.Rel(root, path)
+		if err != nil {
+			return errors.Wrap(err, path)
+		}
+		name = filepath.Join(prefix, name)
+		name = filepath.ToSlash(name)
+
+		// Generate header
+		var link string
+		mode := info.Mode()
+		if mode&os.ModeSymlink != 0 {
+			if link, err = os.Readlink(link); err != nil {
+				return err
+			}
+		}
+		header, err := tar.FileInfoHeader(info, link)
+		if err != nil {
+			return err
+		}
+		header.Name = name
+		header.Uid = 0
+		header.Gid = 0
+		header.Uname = ""
+		header.Gname = ""
+
+		// Write file
+		if err := tw.WriteHeader(header); err != nil {
+			return err
+		}
+		if mode.IsRegular() {
+			file, err := os.Open(path)
+			if err != nil {
+				return errors.Wrap(err, path)
+			}
+			if _, err := io.Copy(tw, file); err != nil {
+				return errors.Wrap(err, path)
+			}
+		}
+
+		return nil
+	}); err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/content/utils.go
+++ b/pkg/content/utils.go
@@ -109,6 +109,8 @@ func extractTarDirectory(root, prefix string, r io.Reader) error {
 		case tar.TypeDir:
 			err = os.MkdirAll(path, header.FileInfo().Mode())
 		case tar.TypeLink:
+			err = os.Link(header.Linkname, path)
+		case tar.TypeSymlink:
 			err = os.Symlink(header.Linkname, path)
 		default:
 			continue // Non-regular files are skipped


### PR DESCRIPTION
This PR enables `oras` to push / pull a directory to / from a remote registry.

To push, the target directory is compressed into a `tar.gz` temproray file (on Linux, it sits at `/tmp`). Then the `tar.gz` file is pushed normally with media type `application/vnd.oci.image.layer.v1.tar+gzip` and extra annotations
- `io.deis.oras.content.digest`: the `sha256` digest of the internal `tar` file. It is different from the digest of the `tar.gz` file.
- `io.deis.oras.content.unpack`: marked as `true` for extration when pull.

To pull, the `tar.gz` file is pulled to a temprorary directory. Then it is extracted and verified against `io.deis.oras.content.digest`.

Notes:
- Since the temp files are introduced, please call `defer store.Close()` for `*FileStore` to release resources.
- The pushed directory can be directly used as a layer of a container image without any modification.

Resolves #54 