### PR TITLE
Customized Config and Annotations Support

### DIFF
--- a/cmd/oras/push.go
+++ b/cmd/oras/push.go
@@ -106,7 +106,15 @@ func runPush(opts pushOptions) error {
 			return err
 		}
 		if annotations != nil {
-			file.Annotations = annotations[filename]
+			if value, ok := annotations[filename]; ok {
+				if file.Annotations == nil {
+					file.Annotations = value
+				} else {
+					for k, v := range value {
+						file.Annotations[k] = v
+					}
+				}
+			}
 		}
 		files = append(files, file)
 	}

--- a/cmd/oras/push.go
+++ b/cmd/oras/push.go
@@ -14,6 +14,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	annotationConfig   = "$config"
+	annotationManifest = "$manifest"
+)
+
 type pushOptions struct {
 	targetRef           string
 	fileRefs            []string
@@ -76,10 +81,10 @@ func runPush(opts pushOptions) error {
 		if err := decodeJSON(opts.manifestAnnotations, &annotations); err != nil {
 			return err
 		}
-		if value, ok := annotations["$config"]; ok {
+		if value, ok := annotations[annotationConfig]; ok {
 			pushOpts = append(pushOpts, oras.WithConfigAnnotations(value))
 		}
-		if value, ok := annotations["$manifest"]; ok {
+		if value, ok := annotations[annotationManifest]; ok {
 			pushOpts = append(pushOpts, oras.WithManifestAnnotations(value))
 		}
 	}
@@ -90,7 +95,7 @@ func runPush(opts pushOptions) error {
 		if len(ref) == 2 {
 			mediaType = ref[1]
 		}
-		file, err := store.Add("$config", mediaType, filename)
+		file, err := store.Add(annotationConfig, mediaType, filename)
 		if err != nil {
 			return err
 		}

--- a/cmd/oras/push.go
+++ b/cmd/oras/push.go
@@ -35,11 +35,14 @@ func pushCmd() *cobra.Command {
 Example - Push file "hi.txt" with the "application/vnd.oci.image.layer.v1.tar" media type (default):
   oras push localhost:5000/hello:latest hi.txt
 
-Example - Pull file "hi.txt" with the custom "application/vnd.me.hi" media type:
+Example - Push file "hi.txt" with the custom "application/vnd.me.hi" media type:
   oras push localhost:5000/hello:latest hi.txt:application/vnd.me.hi
 
 Example - Push multiple files with different media types:
   oras push localhost:5000/hello:latest hi.txt:application/vnd.me.hi bye.txt:application/vnd.me.bye
+
+Example - Push file "hi.txt" with the custom manifest config "config.json" of the custom "application/vnd.me.config" media type:
+  oras push --manifest-config config.json:application/vnd.me.config localhost:5000/hello:latest hi.txt
 `,
 		Args: cobra.MinimumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/oras/push.go
+++ b/pkg/oras/push.go
@@ -12,13 +12,18 @@ import (
 )
 
 // Push pushes files to the remote
-func Push(ctx context.Context, resolver remotes.Resolver, ref string, provider content.Provider, descriptors []ocispec.Descriptor) error {
+func Push(ctx context.Context, resolver remotes.Resolver, ref string, provider content.Provider, descriptors []ocispec.Descriptor, opts ...PushOpt) error {
 	if resolver == nil {
 		return ErrResolverUndefined
 	}
-
 	if len(descriptors) == 0 {
 		return ErrEmptyDescriptors
+	}
+	var opt pushOpts
+	for _, o := range opts {
+		if err := o(&opt); err != nil {
+			return err
+		}
 	}
 
 	pusher, err := resolver.Pusher(ctx, ref)
@@ -26,7 +31,7 @@ func Push(ctx context.Context, resolver remotes.Resolver, ref string, provider c
 		return err
 	}
 
-	desc, provider, err := pack(provider, descriptors)
+	desc, provider, err := pack(provider, opt.config, descriptors)
 	if err != nil {
 		return err
 	}
@@ -34,24 +39,26 @@ func Push(ctx context.Context, resolver remotes.Resolver, ref string, provider c
 	return remotes.PushContent(ctx, pusher, desc, provider, nil)
 }
 
-func pack(provider content.Provider, descriptors []ocispec.Descriptor) (ocispec.Descriptor, content.Provider, error) {
+func pack(provider content.Provider, config *ocispec.Descriptor, descriptors []ocispec.Descriptor) (ocispec.Descriptor, content.Provider, error) {
 	store := newHybridStoreFromProvider(provider)
 
 	// Config
-	configBytes := []byte("{}")
-	config := ocispec.Descriptor{
-		MediaType: ocispec.MediaTypeImageConfig,
-		Digest:    digest.FromBytes(configBytes),
-		Size:      int64(len(configBytes)),
+	if config == nil {
+		configBytes := []byte("{}")
+		config := &ocispec.Descriptor{
+			MediaType: ocispec.MediaTypeImageConfig,
+			Digest:    digest.FromBytes(configBytes),
+			Size:      int64(len(configBytes)),
+		}
+		store.Set(*config, configBytes)
 	}
-	store.Set(config, configBytes)
 
 	// Manifest
 	manifest := ocispec.Manifest{
 		Versioned: specs.Versioned{
 			SchemaVersion: 2, // historical value. does not pertain to OCI or docker version
 		},
-		Config: config,
+		Config: *config,
 		Layers: descriptors,
 	}
 	manifestBytes, err := json.Marshal(manifest)

--- a/pkg/oras/push_opts.go
+++ b/pkg/oras/push_opts.go
@@ -3,7 +3,9 @@ package oras
 import ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 type pushOpts struct {
-	config *ocispec.Descriptor
+	config              *ocispec.Descriptor
+	configAnnotations   map[string]string
+	manifestAnnotations map[string]string
 }
 
 // PushOpt allows callers to set options on the oras push
@@ -13,6 +15,22 @@ type PushOpt func(o *pushOpts) error
 func WithConfig(config ocispec.Descriptor) PushOpt {
 	return func(o *pushOpts) error {
 		o.config = &config
+		return nil
+	}
+}
+
+// WithConfigAnnotations overrides the config annotations
+func WithConfigAnnotations(annotations map[string]string) PushOpt {
+	return func(o *pushOpts) error {
+		o.configAnnotations = annotations
+		return nil
+	}
+}
+
+// WithManifestAnnotations overrides the manifest annotations
+func WithManifestAnnotations(annotations map[string]string) PushOpt {
+	return func(o *pushOpts) error {
+		o.manifestAnnotations = annotations
 		return nil
 	}
 }

--- a/pkg/oras/push_opts.go
+++ b/pkg/oras/push_opts.go
@@ -1,0 +1,18 @@
+package oras
+
+import ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+type pushOpts struct {
+	config *ocispec.Descriptor
+}
+
+// PushOpt allows callers to set options on the oras push
+type PushOpt func(o *pushOpts) error
+
+// WithConfig overrides the config
+func WithConfig(config ocispec.Descriptor) PushOpt {
+	return func(o *pushOpts) error {
+		o.config = &config
+		return nil
+	}
+}


### PR DESCRIPTION
Support customized manifest config by the `--manifest-config file[:type]` option. Similar to the file reference, it is possible to change the media type of the manifest config.

Support customized annotations for the manifest, the config, and individual layers by the `--manifest-annotations file` option. The annotations file is a JSON file with the following format:
```json
{
  "<filename>": {
    "<annotation_key>": "annotation_value"
  }
}
```
There are two special filenames / entries:
- `$config` is reserved for the annotation of the manifest config.
- `$manifest` is reserved for the annotation of the manifest itself.

For instance, the following annotation file
```json
{
  "$config": {
    "hello": "world"
  },
  "$manifest": {
    "foo": "bar"
  },
  "cake.txt": {
    "fun": "more cream"
  }
}
```
results in
```json
{
  "schemaVersion": 2,
  "config": {
    "mediaType": "application/vnd.oci.image.config.v1+json",
    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
    "size": 2,
    "annotations": {
      "hello": "world"
    }
  },
  "layers": [
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar",
      "digest": "sha256:22af0898315a239117308d39acd80636326c4987510b0ec6848e58eb584ba82e",
      "size": 6,
      "annotations": {
        "fun": "more cream",
        "org.opencontainers.image.title": "cake.txt"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar",
      "digest": "sha256:be6fe11876282442bead98e8b24aca07f8972a763cd366c56b4b5f7bcdd23eac",
      "size": 7,
      "annotations": {
        "org.opencontainers.image.title": "juice.txt"
      }
    }
  ],
  "annotations": {
    "foo": "bar"
  }
}
```

Resolves #50 
Related #52 