### PR TITLE
Update dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -45,7 +45,7 @@
   version = "v0.4.1"
 
 [[projects]]
-  digest = "1:7643865a2cdb66fb14d8361611a75b370a99211ac44983505b3eecb4a6a7a882"
+  digest = "1:0e3ee0c357dba5073fa9ac183b3380fc3c500e8eca5d3b951b00a6bb8415664e"
   name = "github.com/bugsnag/bugsnag-go"
   packages = [
     ".",
@@ -55,7 +55,8 @@
     "sessions",
   ]
   pruneopts = "UT"
-  revision = "109a9d63f2b57c4623f4912b256bac4a7a63517d"
+  revision = "d5b63da7e1f93d83e3980e5ab2bf33179bad7b2a"
+  version = "v1.5.0"
 
 [[projects]]
   digest = "1:3049c43c6d1cfaa347acd27d6342187f8f38d9f416bbba7b02b43f82848302d2"
@@ -66,7 +67,7 @@
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:1872596d45cb52913fcdea90d468f3e57435959e9c0d99ccb316ee76de341313"
+  digest = "1:37f8940c4d3c41536ea882b1ca3498e403c04892dfc34bd0d670ed9eafccda9a"
   name = "github.com/containerd/containerd"
   packages = [
     "content",
@@ -79,8 +80,8 @@
     "remotes/docker",
   ]
   pruneopts = "UT"
-  revision = "9754871865f7fe2f4e74d43e2fc7ccd237edcbce"
-  version = "v1.2.2"
+  revision = "894b81a4b802e4eb2a91d1ce216b8817763c29fb"
+  version = "v1.2.6"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,7 +4,7 @@
 
 [[constraint]]
   name = "github.com/containerd/containerd"
-  version = "1.2.1"
+  version = "1.2.6"
 
 [[constraint]]
   name = "github.com/opencontainers/go-digest"
@@ -17,25 +17,9 @@
 # Test dependency
 [[constraint]]
   name = "github.com/docker/distribution"
-  version = "^2.7.1"
+  version = "v2.7.1"
 
 # These overrides below necessary for using docker/distribution as a test dependency
-[[override]]
-  name = "github.com/yvasiyarov/newrelic_platform_go"
-  revision = "b21fdbd4370f3717f3bbd2bf41c223bc273068e6"
-
-[[override]]
-  name = "github.com/miekg/dns"
-  revision = "0d29b283ac0f967dd3a02739bf26a22702210d7a"
-
-[[override]]
-  name = "github.com/xenolf/lego"
-  revision = "a9d8cec0e6563575e5868a005359ac97911b5985"
-
-[[override]]
-  name = "github.com/bugsnag/bugsnag-go"
-  revision = "109a9d63f2b57c4623f4912b256bac4a7a63517d"
-
 [[override]]
   name = "rsc.io/letsencrypt"
   branch = "master"


### PR DESCRIPTION
Resolves #58 

Bump up
- `containerd/containerd` from `1.2.1` to `1.2.6`. 
- `docker/distribution` from `^2.7.1` to `v2.7.1`