### PR TITLE
Print oras version

### DIFF
--- a/cmd/oras/main.go
+++ b/cmd/oras/main.go
@@ -10,6 +10,7 @@ func main() {
 	cmd := &cobra.Command{
 		Use:          "oras [command]",
 		SilenceUsage: true,
+		Version:      "v0.4.0",
 	}
 	cmd.AddCommand(pullCmd(), pushCmd(), loginCmd(), logoutCmd())
 	if err := cmd.Execute(); err != nil {

--- a/cmd/oras/main.go
+++ b/cmd/oras/main.go
@@ -10,7 +10,7 @@ func main() {
 	cmd := &cobra.Command{
 		Use:          "oras [command]",
 		SilenceUsage: true,
-		Version:      "v0.4.0",
+		Version:      "0.4.0",
 	}
 	cmd.AddCommand(pullCmd(), pushCmd(), loginCmd(), logoutCmd())
 	if err := cmd.Execute(); err != nil {


### PR DESCRIPTION
Run `oras --version` to print the version
```
$ oras --version
oras version 0.4.0
```

Resolves #49 