### PR TITLE
Cross-platform support on path

### DIFF
--- a/cmd/oras/push.go
+++ b/cmd/oras/push.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"os"
-	"strings"
 
 	"github.com/deislabs/oras/pkg/content"
 	"github.com/deislabs/oras/pkg/oras"
@@ -91,12 +90,7 @@ func runPush(opts pushOptions) error {
 		}
 	}
 	if opts.manifestConfigRef != "" {
-		ref := strings.SplitN(opts.manifestConfigRef, ":", 2)
-		filename := ref[0]
-		mediaType := ocispec.MediaTypeImageConfig
-		if len(ref) == 2 {
-			mediaType = ref[1]
-		}
+		filename, mediaType := parseFileRef(opts.manifestConfigRef, ocispec.MediaTypeImageConfig)
 		file, err := store.Add(annotationConfig, mediaType, filename)
 		if err != nil {
 			return err
@@ -105,12 +99,7 @@ func runPush(opts pushOptions) error {
 		pushOpts = append(pushOpts, oras.WithConfig(file))
 	}
 	for _, fileRef := range opts.fileRefs {
-		ref := strings.SplitN(fileRef, ":", 2)
-		filename := ref[0]
-		var mediaType string
-		if len(ref) == 2 {
-			mediaType = ref[1]
-		}
+		filename, mediaType := parseFileRef(fileRef, "")
 		file, err := store.Add(filename, mediaType, "")
 		if err != nil {
 			return err

--- a/cmd/oras/push.go
+++ b/cmd/oras/push.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"path/filepath"
 
 	"github.com/deislabs/oras/pkg/content"
 	"github.com/deislabs/oras/pkg/oras"
@@ -100,7 +101,12 @@ func runPush(opts pushOptions) error {
 	}
 	for _, fileRef := range opts.fileRefs {
 		filename, mediaType := parseFileRef(fileRef, "")
-		file, err := store.Add(filename, mediaType, "")
+		name := filepath.Clean(filename)
+		if !filepath.IsAbs(name) {
+			// convert to slash-separated path unless it is absolute path
+			name = filepath.ToSlash(name)
+		}
+		file, err := store.Add(name, mediaType, filename)
 		if err != nil {
 			return err
 		}

--- a/cmd/oras/push_unix.go
+++ b/cmd/oras/push_unix.go
@@ -1,0 +1,13 @@
+// +build !windows
+
+package main
+
+import "strings"
+
+func parseFileRef(ref string, mediaType string) (string, string) {
+	i := strings.LastIndex(ref, ":")
+	if i < 0 {
+		return ref, mediaType
+	}
+	return ref[:i], ref[i+1:]
+}

--- a/cmd/oras/push_windows.go
+++ b/cmd/oras/push_windows.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"strings"
+	"unicode"
+)
+
+// parseFileRef parse file reference on windows.
+// Windows systems does not allow ':' in the file path except for drive letter.
+func parseFileRef(ref string, mediaType string) (string, string) {
+	i := strings.Index(ref, ":")
+	if i < 0 {
+		return ref, mediaType
+	}
+
+	// In case it is C:\
+	if i == 1 && len(ref) > 2 && ref[2] == '\\' && unicode.IsLetter(rune(ref[0])) {
+		i = strings.Index(ref[3:], ":")
+		if i < 0 {
+			return ref, mediaType
+		}
+		i += 3
+	}
+
+	return ref[:i], ref[i+1:]
+}


### PR DESCRIPTION
Better cross-platform support on Windows.

With this patch,
- Windows path are automatically converted to "/" except absolute paths. For instances,
  - `foo\bar\hello.txt` --> `foo/bar/hello.txt`
  - `C:\hello.txt` --> `C:\hello.txt` (no change)
- Allow file reference with Windows absolute paths. For instance,
  - `C:\hello.txt`
  - `C:\hello.txt:vnd.your.media.type`

Fixes #62, #63