### PR TITLE
Logout returns error if not logged in

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -113,7 +113,7 @@
   version = "v18.09.1"
 
 [[projects]]
-  digest = "1:e5d368e406b0d21ccea6737852e32eb3532c43a1732668f6676fbdfba7e8f02d"
+  digest = "1:a2c9e1bc5a6c59b4a0c79a003baac90d0c496881c2ec0663579543c2192fa0ed"
   name = "github.com/docker/distribution"
   packages = [
     ".",
@@ -134,6 +134,7 @@
     "registry/api/errcode",
     "registry/api/v2",
     "registry/auth",
+    "registry/auth/htpasswd",
     "registry/client",
     "registry/client/auth",
     "registry/client/auth/challenge",
@@ -509,9 +510,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:2af384bf8f275e9bd00280fe7baa475fd336e1d198a272452adf14275f05fb5e"
+  digest = "1:8cc146ad95f6179d301d6169c4878a757ede043c020830ab04a2b97f28eaae0f"
   name = "golang.org/x/crypto"
   packages = [
+    "bcrypt",
+    "blowfish",
     "ed25519",
     "ed25519/internal/edwards25519",
     "ocsp",
@@ -653,6 +656,7 @@
     "github.com/docker/cli/cli/config/credentials",
     "github.com/docker/distribution/configuration",
     "github.com/docker/distribution/registry",
+    "github.com/docker/distribution/registry/auth/htpasswd",
     "github.com/docker/distribution/registry/storage/driver/inmemory",
     "github.com/docker/docker/api/types",
     "github.com/docker/docker/pkg/term",
@@ -665,6 +669,7 @@
     "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",
     "github.com/stretchr/testify/suite",
+    "golang.org/x/crypto/bcrypt",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/auth/client.go
+++ b/pkg/auth/client.go
@@ -2,8 +2,14 @@ package auth
 
 import (
 	"context"
+	"errors"
 
 	"github.com/containerd/containerd/remotes"
+)
+
+// Common errors
+var (
+	ErrNotLoggedIn = errors.New("not_logged_in")
 )
 
 // Client provides authentication operations for remotes.

--- a/pkg/auth/client.go
+++ b/pkg/auth/client.go
@@ -9,7 +9,7 @@ import (
 
 // Common errors
 var (
-	ErrNotLoggedIn = errors.New("not_logged_in")
+	ErrNotLoggedIn = errors.New("not logged in")
 )
 
 // Client provides authentication operations for remotes.

--- a/pkg/auth/docker/client_test.go
+++ b/pkg/auth/docker/client_test.go
@@ -48,10 +48,6 @@ func (suite *DockerClientTestSuite) SetupSuite() {
 	suite.Client, ok = client.(*Client)
 	suite.True(ok, "NewClient returns a *docker.Client inside")
 
-	// Disable credential store for testing
-	// suite.True(len(suite.Client.configs) != 0, "client has config loaded")
-	// suite.Client.configs[0].CredentialsStore = ""
-
 	// Create htpasswd file with bcrypt
 	secret, err := bcrypt.GenerateFromPassword([]byte(testPassword), bcrypt.DefaultCost)
 	suite.Nil(err, "no error generating bcrypt password for test htpasswd file")

--- a/pkg/auth/docker/client_test.go
+++ b/pkg/auth/docker/client_test.go
@@ -1,0 +1,109 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/docker/distribution/configuration"
+	"github.com/docker/distribution/registry"
+	_ "github.com/docker/distribution/registry/auth/htpasswd"
+	_ "github.com/docker/distribution/registry/storage/driver/inmemory"
+	"github.com/phayes/freeport"
+	"github.com/stretchr/testify/suite"
+	"golang.org/x/crypto/bcrypt"
+)
+
+var (
+	testConfig   = "test.config"
+	testHtpasswd = "test.htpasswd"
+	testUsername = "alice"
+	testPassword = "wonderland"
+)
+
+type DockerClientTestSuite struct {
+	suite.Suite
+	DockerRegistryHost string
+	Client             *Client
+	TempTestDir        string
+}
+
+func newContext() context.Context {
+	return context.Background()
+}
+
+func (suite *DockerClientTestSuite) SetupSuite() {
+	tempDir, err := ioutil.TempDir("", "oras_auth_docker_test")
+	suite.Nil(err, "no error creating temp directory for test")
+	suite.TempTestDir = tempDir
+
+	// Create client
+	client, err := NewClient(filepath.Join(suite.TempTestDir, testConfig))
+	suite.Nil(err, "no error creating client")
+	var ok bool
+	suite.Client, ok = client.(*Client)
+	suite.True(ok, "NewClient returns a *docker.Client inside")
+
+	// Disable credential store for testing
+	// suite.True(len(suite.Client.configs) != 0, "client has config loaded")
+	// suite.Client.configs[0].CredentialsStore = ""
+
+	// Create htpasswd file with bcrypt
+	secret, err := bcrypt.GenerateFromPassword([]byte(testPassword), bcrypt.DefaultCost)
+	suite.Nil(err, "no error generating bcrypt password for test htpasswd file")
+	authRecord := fmt.Sprintf("%s:%s\n", testUsername, string(secret))
+	htpasswdPath := filepath.Join(suite.TempTestDir, testHtpasswd)
+	err = ioutil.WriteFile(htpasswdPath, []byte(authRecord), 0644)
+	suite.Nil(err, "no error creating test htpasswd file")
+
+	// Registry config
+	config := &configuration.Configuration{}
+	port, err := freeport.GetFreePort()
+	suite.Nil(err, "no error finding free port for test registry")
+	suite.DockerRegistryHost = fmt.Sprintf("localhost:%d", port)
+	config.HTTP.Addr = fmt.Sprintf(":%d", port)
+	config.HTTP.DrainTimeout = time.Duration(10) * time.Second
+	config.Storage = map[string]configuration.Parameters{"inmemory": map[string]interface{}{}}
+	config.Auth = configuration.Auth{
+		"htpasswd": configuration.Parameters{
+			"realm": "localhost",
+			"path":  htpasswdPath,
+		},
+	}
+	dockerRegistry, err := registry.NewRegistry(context.Background(), config)
+	suite.Nil(err, "no error finding free port for test registry")
+
+	// Start Docker registry
+	go dockerRegistry.ListenAndServe()
+}
+
+func (suite *DockerClientTestSuite) TearDownSuite() {
+	os.RemoveAll(suite.TempTestDir)
+}
+
+func (suite *DockerClientTestSuite) Test_0_Login() {
+	var err error
+
+	err = suite.Client.Login(newContext(), suite.DockerRegistryHost, "oscar", "opponent")
+	suite.NotNil(err, "error logging into registry with invalid credentials")
+
+	err = suite.Client.Login(newContext(), suite.DockerRegistryHost, testUsername, testPassword)
+	suite.Nil(err, "no error logging into registry with valid credentials")
+}
+func (suite *DockerClientTestSuite) Test_2_Logout() {
+	var err error
+
+	err = suite.Client.Logout(newContext(), "non-existing-host:42")
+	suite.NotNil(err, "error logging out of registry that has no entry")
+
+	err = suite.Client.Logout(newContext(), suite.DockerRegistryHost)
+	suite.Nil(err, "no error logging out of registry")
+}
+
+func TestDockerClientTestSuite(t *testing.T) {
+	suite.Run(t, new(DockerClientTestSuite))
+}

--- a/pkg/auth/docker/logout.go
+++ b/pkg/auth/docker/logout.go
@@ -1,9 +1,27 @@
 package docker
 
-import "context"
+import (
+	"context"
+
+	"github.com/deislabs/oras/pkg/auth"
+
+	"github.com/docker/cli/cli/config/configfile"
+)
 
 // Logout logs out from a docker registry identified by the hostname.
 func (c *Client) Logout(_ context.Context, hostname string) error {
 	hostname = resolveHostname(hostname)
+
+	var configs []*configfile.ConfigFile
+	for _, config := range c.configs {
+		if _, ok := config.AuthConfigs[hostname]; ok {
+			configs = append(configs, config)
+		}
+	}
+	if len(configs) == 0 {
+		return auth.ErrNotLoggedIn
+	}
+
+	// Log out form the primary config only as backups are read-only.
 	return c.primaryCredentialsStore(hostname).Erase(hostname)
 }


### PR DESCRIPTION
`Logout` returns `ErrNotLoggedIn` if a registry is not logged in.
If the multiple config paths are used, the check will verify the login record against all configs. However, it only logs out from the primary config setting since the backup configs are supposed to be read-only.

Resovles #71 