### PR TITLE
Error Log Level on Push/Pull by default

### DIFF
--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -64,11 +64,10 @@ Example - Pull all files, any media type:
 }
 
 func runPull(opts pullOptions) error {
-	if !opts.verbose {
-		logrus.SetLevel(logrus.ErrorLevel)
-	}
 	if opts.debug {
 		logrus.SetLevel(logrus.DebugLevel)
+	} else {
+		logrus.SetLevel(logrus.ErrorLevel)
 	}
 	if opts.allowAllMediaTypes {
 		opts.allowedMediaTypes = nil

--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -64,6 +64,9 @@ Example - Pull all files, any media type:
 }
 
 func runPull(opts pullOptions) error {
+	if !opts.verbose {
+		logrus.SetLevel(logrus.ErrorLevel)
+	}
 	if opts.debug {
 		logrus.SetLevel(logrus.DebugLevel)
 	}

--- a/cmd/oras/push.go
+++ b/cmd/oras/push.go
@@ -25,6 +25,7 @@ type pushOptions struct {
 	manifestConfigRef      string
 	manifestAnnotations    string
 	pathValidationDisabled bool
+	verbose                bool
 
 	debug    bool
 	configs  []string
@@ -62,6 +63,7 @@ Example - Push file "hi.txt" with the custom manifest config "config.json" of th
 	cmd.Flags().StringVarP(&opts.manifestConfigRef, "manifest-config", "", "", "manifest config file")
 	cmd.Flags().StringVarP(&opts.manifestAnnotations, "manifest-annotations", "", "", "manifest annotation file")
 	cmd.Flags().BoolVarP(&opts.pathValidationDisabled, "disable-path-validation", "", false, "skip path validation")
+	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", false, "verbose output")
 	cmd.Flags().BoolVarP(&opts.debug, "debug", "d", false, "debug mode")
 	cmd.Flags().StringArrayVarP(&opts.configs, "config", "c", nil, "auth config path")
 	cmd.Flags().StringVarP(&opts.username, "username", "u", "", "registry username")
@@ -70,6 +72,9 @@ Example - Push file "hi.txt" with the custom manifest config "config.json" of th
 }
 
 func runPush(opts pushOptions) error {
+	if !opts.verbose {
+		logrus.SetLevel(logrus.ErrorLevel)
+	}
 	if opts.debug {
 		logrus.SetLevel(logrus.DebugLevel)
 	}

--- a/cmd/oras/push.go
+++ b/cmd/oras/push.go
@@ -25,7 +25,6 @@ type pushOptions struct {
 	manifestConfigRef      string
 	manifestAnnotations    string
 	pathValidationDisabled bool
-	verbose                bool
 
 	debug    bool
 	configs  []string
@@ -63,7 +62,6 @@ Example - Push file "hi.txt" with the custom manifest config "config.json" of th
 	cmd.Flags().StringVarP(&opts.manifestConfigRef, "manifest-config", "", "", "manifest config file")
 	cmd.Flags().StringVarP(&opts.manifestAnnotations, "manifest-annotations", "", "", "manifest annotation file")
 	cmd.Flags().BoolVarP(&opts.pathValidationDisabled, "disable-path-validation", "", false, "skip path validation")
-	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", false, "verbose output")
 	cmd.Flags().BoolVarP(&opts.debug, "debug", "d", false, "debug mode")
 	cmd.Flags().StringArrayVarP(&opts.configs, "config", "c", nil, "auth config path")
 	cmd.Flags().StringVarP(&opts.username, "username", "u", "", "registry username")
@@ -72,11 +70,10 @@ Example - Push file "hi.txt" with the custom manifest config "config.json" of th
 }
 
 func runPush(opts pushOptions) error {
-	if !opts.verbose {
-		logrus.SetLevel(logrus.ErrorLevel)
-	}
 	if opts.debug {
 		logrus.SetLevel(logrus.DebugLevel)
+	} else {
+		logrus.SetLevel(logrus.ErrorLevel)
 	}
 
 	// load files


### PR DESCRIPTION
By default, the log level is set to `logrus.ErrorLevel` to avoid warnings like
```
WARN[0000] unknown_type: application/vnd.oci.image.config.v1+json
```
To debug, users can always toggle `--debug, -d` options to set the log level to `logrus.DebugLevel`.

@jdolitsky For `helm` invoking `oras` while do not want to bother log level for omitting warnings, please set the proper `GetLogger` at https://github.com/containerd/containerd/blob/master/log/context.go#L31

@sajayantony In terms of the user experiences, what do you think about those warnings?