### PR TITLE
Discard logger

### DIFF
--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/deislabs/oras/pkg/content"
+	ctxo "github.com/deislabs/oras/pkg/context"
 	"github.com/deislabs/oras/pkg/oras"
 
 	"github.com/sirupsen/logrus"
@@ -64,8 +65,11 @@ Example - Pull all files, any media type:
 }
 
 func runPull(opts pullOptions) error {
+	ctx := context.Background()
 	if opts.debug {
 		logrus.SetLevel(logrus.DebugLevel)
+	} else {
+		ctx = ctxo.WithLoggerDiscarded(ctx)
 	}
 	if opts.allowAllMediaTypes {
 		opts.allowedMediaTypes = nil
@@ -78,7 +82,7 @@ func runPull(opts pullOptions) error {
 	defer store.Close()
 	store.DisableOverwrite = opts.keepOldFiles
 	store.AllowPathTraversalOnWrite = opts.pathTraversal
-	desc, files, err := oras.Pull(context.Background(), resolver, opts.targetRef, store, oras.WithAllowedMediaTypes(opts.allowedMediaTypes))
+	desc, files, err := oras.Pull(ctx, resolver, opts.targetRef, store, oras.WithAllowedMediaTypes(opts.allowedMediaTypes))
 	if err != nil {
 		return err
 	}

--- a/cmd/oras/push.go
+++ b/cmd/oras/push.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/deislabs/oras/pkg/content"
+	ctxo "github.com/deislabs/oras/pkg/context"
 	"github.com/deislabs/oras/pkg/oras"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -73,8 +74,11 @@ Example - Push file "hi.txt" with the custom manifest config "config.json" of th
 }
 
 func runPush(opts pushOptions) error {
+	ctx := context.Background()
 	if opts.debug {
 		logrus.SetLevel(logrus.DebugLevel)
+	} else {
+		ctx = ctxo.WithLoggerDiscarded(ctx)
 	}
 
 	// load files
@@ -138,7 +142,7 @@ func runPush(opts pushOptions) error {
 
 	// ready to push
 	resolver := newResolver(opts.username, opts.password, opts.configs...)
-	desc, err := oras.Push(context.Background(), resolver, opts.targetRef, store, files, pushOpts...)
+	desc, err := oras.Push(ctx, resolver, opts.targetRef, store, files, pushOpts...)
 	if err != nil {
 		return err
 	}

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -1,0 +1,9 @@
+package context
+
+import "context"
+
+// Background returns a default context with logger discarded.
+func Background() context.Context {
+	ctx := context.Background()
+	return WithLoggerDiscarded(ctx)
+}

--- a/pkg/context/logger.go
+++ b/pkg/context/logger.go
@@ -1,0 +1,35 @@
+package context
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+
+	"github.com/containerd/containerd/log"
+	"github.com/sirupsen/logrus"
+)
+
+// WithLogger returns a new context with the provided logger.
+// This method wraps github.com/containerd/containerd/log.WithLogger()
+func WithLogger(ctx context.Context, logger *logrus.Entry) context.Context {
+	return log.WithLogger(ctx, logger)
+}
+
+// WithLoggerFromWriter returns a new context with the logger, writting to the provided logger.
+func WithLoggerFromWriter(ctx context.Context, writer io.Writer) context.Context {
+	logger := logrus.New()
+	logger.Out = writer
+	entry := logrus.NewEntry(logger)
+	return WithLogger(ctx, entry)
+}
+
+// WithLoggerDiscarded returns a new context with the logger, writting to nothing.
+func WithLoggerDiscarded(ctx context.Context) context.Context {
+	return WithLoggerFromWriter(ctx, ioutil.Discard)
+}
+
+// GetLogger retrieves the current logger from the context.
+// This method wraps github.com/containerd/containerd/log.GetLogger()
+func GetLogger(ctx context.Context) *logrus.Entry {
+	return log.GetLogger(ctx)
+}


### PR DESCRIPTION
Discard logger by default unless `--debug` is toggled.

@jdolitsky Take a look at `pkg/context/logger.go`. You may need `WithLoggerFromWriter()` or `WithLoggerDiscarded()` for helm 3.

Resolves #72