### PR TITLE
Allow sequential pulling with break in the middle

### DIFF
--- a/pkg/oras/errors.go
+++ b/pkg/oras/errors.go
@@ -20,4 +20,5 @@ var (
 )
 
 // ErrStopProcessing is used to stop processing an oras operation.
+// This error only makes sense in sequential pulling operation.
 var ErrStopProcessing = fmt.Errorf("stop processing")

--- a/pkg/oras/errors.go
+++ b/pkg/oras/errors.go
@@ -1,17 +1,23 @@
 package oras
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // Common errors
 var (
-	ErrResolverUndefined = errors.New("resolver_undefined")
-	ErrEmptyDescriptors  = errors.New("empty_descriptors")
+	ErrResolverUndefined = errors.New("resolver undefined")
+	ErrEmptyDescriptors  = errors.New("empty descriptors")
 )
 
 // Path validation related errors
 var (
-	ErrDirtyPath               = errors.New("dirty_path")
-	ErrPathNotSlashSeparated   = errors.New("path_not_slash_separated")
-	ErrAbsolutePathDisallowed  = errors.New("absolute_path_disallowed")
-	ErrPathTraversalDisallowed = errors.New("path_traversal_disallowed")
+	ErrDirtyPath               = errors.New("dirty path")
+	ErrPathNotSlashSeparated   = errors.New("path not slash separated")
+	ErrAbsolutePathDisallowed  = errors.New("absolute path disallowed")
+	ErrPathTraversalDisallowed = errors.New("path traversal disallowed")
 )
+
+// ErrStopProcessing is used to stop processing an oras operation.
+var ErrStopProcessing = fmt.Errorf("stop processing")

--- a/pkg/oras/pull.go
+++ b/pkg/oras/pull.go
@@ -68,11 +68,7 @@ func fetchContent(ctx context.Context, fetcher remotes.Fetcher, desc ocispec.Des
 		images.ChildrenHandler(store),
 	)
 
-	dispatch := images.Dispatch
-	if opts.inSequence {
-		dispatch = dispatchBFS
-	}
-	if err := dispatch(ctx, images.Handlers(handlers...), desc); err != nil {
+	if err := opts.dispatch(ctx, images.Handlers(handlers...), desc); err != nil {
 		return nil, err
 	}
 

--- a/pkg/oras/pull.go
+++ b/pkg/oras/pull.go
@@ -58,8 +58,11 @@ func fetchContent(ctx context.Context, fetcher remotes.Fetcher, desc ocispec.Des
 		return nil, nil
 	})
 	store := newHybridStoreFromIngester(ingester)
-	handlers := images.Handlers(
+	handlers := []images.Handler{
 		filterHandler(opts.allowedMediaTypes...),
+	}
+	handlers = append(handlers, opts.baseHandlers...)
+	handlers = append(handlers,
 		remotes.FetchHandler(store, fetcher),
 		picker,
 		images.ChildrenHandler(store),
@@ -69,7 +72,7 @@ func fetchContent(ctx context.Context, fetcher remotes.Fetcher, desc ocispec.Des
 	if opts.inSequence {
 		dispatch = dispatchBFS
 	}
-	if err := dispatch(ctx, handlers, desc); err != nil {
+	if err := dispatch(ctx, images.Handlers(handlers...), desc); err != nil {
 		return nil, err
 	}
 

--- a/pkg/oras/pull.go
+++ b/pkg/oras/pull.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/remotes"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
 )
 
 // Pull pull files from the remote
@@ -35,18 +36,18 @@ func Pull(ctx context.Context, resolver remotes.Resolver, ref string, ingester c
 		return ocispec.Descriptor{}, nil, err
 	}
 
-	layers, err := fetchContent(ctx, fetcher, desc, ingester, opt.allowedMediaTypes...)
+	layers, err := fetchContent(ctx, fetcher, desc, ingester, opt)
 	if err != nil {
 		return ocispec.Descriptor{}, nil, err
 	}
 	return desc, layers, nil
 }
 
-func fetchContent(ctx context.Context, fetcher remotes.Fetcher, desc ocispec.Descriptor, ingester content.Ingester, allowedMediaTypes ...string) ([]ocispec.Descriptor, error) {
+func fetchContent(ctx context.Context, fetcher remotes.Fetcher, desc ocispec.Descriptor, ingester content.Ingester, opts *pullOpts) ([]ocispec.Descriptor, error) {
 	var descriptors []ocispec.Descriptor
 	lock := &sync.Mutex{}
 	picker := images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-		if isAllowedMediaType(desc.MediaType, allowedMediaTypes...) {
+		if isAllowedMediaType(desc.MediaType, opts.allowedMediaTypes...) {
 			if name, ok := orascontent.ResolveName(desc); ok && len(name) > 0 {
 				lock.Lock()
 				defer lock.Unlock()
@@ -58,12 +59,17 @@ func fetchContent(ctx context.Context, fetcher remotes.Fetcher, desc ocispec.Des
 	})
 	store := newHybridStoreFromIngester(ingester)
 	handlers := images.Handlers(
-		filterHandler(allowedMediaTypes...),
+		filterHandler(opts.allowedMediaTypes...),
 		remotes.FetchHandler(store, fetcher),
 		picker,
 		images.ChildrenHandler(store),
 	)
-	if err := images.Dispatch(ctx, handlers, desc); err != nil {
+
+	dispatch := images.Dispatch
+	if opts.inSequence {
+		dispatch = dispatchBFS
+	}
+	if err := dispatch(ctx, handlers, desc); err != nil {
 		return nil, err
 	}
 
@@ -79,9 +85,9 @@ func filterHandler(allowedMediaTypes ...string) images.HandlerFunc {
 			if name, ok := orascontent.ResolveName(desc); ok && len(name) > 0 {
 				return nil, nil
 			}
-			log.G(ctx).Warnf("blob_no_name: %v", desc.Digest)
+			log.G(ctx).Warnf("blob no name: %v", desc.Digest)
 		default:
-			log.G(ctx).Warnf("unknown_type: %v", desc.MediaType)
+			log.G(ctx).Warnf("unknown type: %v", desc.MediaType)
 		}
 		return nil, images.ErrStopHandler
 	}
@@ -97,4 +103,23 @@ func isAllowedMediaType(mediaType string, allowedMediaTypes ...string) bool {
 		}
 	}
 	return false
+}
+
+// dispatchBFS behaves the same as images.Dispatch() but in sequence with breath-first search.
+func dispatchBFS(ctx context.Context, handler images.Handler, descs ...ocispec.Descriptor) error {
+	for i := 0; i < len(descs); i++ {
+		desc := descs[i]
+		children, err := handler.Handle(ctx, desc)
+		if err != nil {
+			switch err := errors.Cause(err); err {
+			case images.ErrSkipDesc:
+				continue // don't traverse the children.
+			case ErrStopProcessing:
+				return nil
+			}
+			return err
+		}
+		descs = append(descs, children...)
+	}
+	return nil
 }

--- a/pkg/oras/pull_opts.go
+++ b/pkg/oras/pull_opts.go
@@ -1,10 +1,15 @@
 package oras
 
-import "github.com/containerd/containerd/images"
+import (
+	"context"
+
+	"github.com/containerd/containerd/images"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
 
 type pullOpts struct {
 	allowedMediaTypes []string
-	inSequence        bool
+	dispatch          func(context.Context, images.Handler, ...ocispec.Descriptor) error
 	baseHandlers      []images.Handler
 }
 
@@ -12,7 +17,9 @@ type pullOpts struct {
 type PullOpt func(o *pullOpts) error
 
 func pullOptsDefaults() *pullOpts {
-	return &pullOpts{}
+	return &pullOpts{
+		dispatch: images.Dispatch,
+	}
 }
 
 // WithAllowedMediaType sets the allowed media types
@@ -31,9 +38,9 @@ func WithAllowedMediaTypes(allowedMediaTypes []string) PullOpt {
 	}
 }
 
-// WithPullInSequence opt to pull in sequence with breath-first search
-func WithPullInSequence(o *pullOpts) error {
-	o.inSequence = true
+// WithPullByBFS opt to pull in sequence with breath-first search
+func WithPullByBFS(o *pullOpts) error {
+	o.dispatch = dispatchBFS
 	return nil
 }
 

--- a/pkg/oras/pull_opts.go
+++ b/pkg/oras/pull_opts.go
@@ -1,8 +1,11 @@
 package oras
 
+import "github.com/containerd/containerd/images"
+
 type pullOpts struct {
 	allowedMediaTypes []string
 	inSequence        bool
+	baseHandlers      []images.Handler
 }
 
 // PullOpt allows callers to set options on the oras pull
@@ -32,4 +35,13 @@ func WithAllowedMediaTypes(allowedMediaTypes []string) PullOpt {
 func WithPullInSequence(o *pullOpts) error {
 	o.inSequence = true
 	return nil
+}
+
+// WithPullBaseHandler provides base handlers, which will be called before
+// any pull specific handlers.
+func WithPullBaseHandler(handlers ...images.Handler) PullOpt {
+	return func(o *pullOpts) error {
+		o.baseHandlers = append(o.baseHandlers, handlers...)
+		return nil
+	}
 }

--- a/pkg/oras/pull_opts.go
+++ b/pkg/oras/pull_opts.go
@@ -2,6 +2,7 @@ package oras
 
 type pullOpts struct {
 	allowedMediaTypes []string
+	inSequence        bool
 }
 
 // PullOpt allows callers to set options on the oras pull
@@ -25,4 +26,10 @@ func WithAllowedMediaTypes(allowedMediaTypes []string) PullOpt {
 		o.allowedMediaTypes = append(o.allowedMediaTypes, allowedMediaTypes...)
 		return nil
 	}
+}
+
+// WithPullInSequence opt to pull in sequence with breath-first search
+func WithPullInSequence(o *pullOpts) error {
+	o.inSequence = true
+	return nil
 }

--- a/pkg/oras/push.go
+++ b/pkg/oras/push.go
@@ -43,7 +43,7 @@ func Push(ctx context.Context, resolver remotes.Resolver, ref string, provider c
 		return ocispec.Descriptor{}, err
 	}
 
-	if err := remotes.PushContent(ctx, pusher, desc, provider, nil); err != nil {
+	if err := remotes.PushContent(ctx, pusher, desc, provider, nil, opt.baseHandlers...); err != nil {
 		return ocispec.Descriptor{}, err
 	}
 	return desc, nil

--- a/pkg/oras/push_opts.go
+++ b/pkg/oras/push_opts.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/containerd/containerd/images"
 	orascontent "github.com/deislabs/oras/pkg/content"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -15,6 +16,7 @@ type pushOpts struct {
 	configAnnotations   map[string]string
 	manifestAnnotations map[string]string
 	validateName        func(desc ocispec.Descriptor) error
+	baseHandlers        []images.Handler
 }
 
 func pushOptsDefaults() *pushOpts {
@@ -97,4 +99,13 @@ func ValidateNameAsPath(desc ocispec.Descriptor) error {
 	}
 
 	return nil
+}
+
+// WithPushBaseHandler provides base handlers, which will be called before
+// any push specific handlers.
+func WithPushBaseHandler(handlers ...images.Handler) PushOpt {
+	return func(o *pushOpts) error {
+		o.baseHandlers = append(o.baseHandlers, handlers...)
+		return nil
+	}
 }


### PR DESCRIPTION
The caller can opt to pull contents in sequence with breath-first search. For example,
```go
oras.Pull(ctx, resolver, ref, store, oras.WithPullByBFS)
```

Combining with the `oras.WithPullBaseHandler` option, the caller is able to conditional pulling. Here is the example code.
```go
oras.Pull(ctx, resolver, ref, store, oras.WithPullByBFS,
	oras.WithPullBaseHandler(images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
		if !shouldContinue(ctx, desc) {
			// the blob of the current descriptor is not pulled
			return nil, oras.ErrStopProcessing
		}
		return nil, nil
	})))
```
Details see `oras_test.go`.

Resolves #75 
Resolves #76