### PR TITLE
Better UX on Push / Pull

### DIFF
--- a/cmd/oras/push.go
+++ b/cmd/oras/push.go
@@ -166,7 +166,7 @@ func decodeJSON(filename string, v interface{}) error {
 
 func pushStatusTrack(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 	if name, ok := content.ResolveName(desc); ok {
-		fmt.Println("Uploading", desc.Digest, name)
+		fmt.Println("Uploading", desc.Digest.Encoded()[:12], name)
 	}
 	return nil, nil
 }

--- a/cmd/oras/push.go
+++ b/cmd/oras/push.go
@@ -113,7 +113,7 @@ func runPush(opts pushOptions) error {
 	if opts.pathValidationDisabled {
 		pushOpts = append(pushOpts, oras.WithNameValidation(nil))
 	}
-	files, annotations, err := loadFiles(store, annotations, &opts)
+	files, err := loadFiles(store, annotations, &opts)
 	if err != nil {
 		return err
 	}
@@ -141,7 +141,7 @@ func decodeJSON(filename string, v interface{}) error {
 	return json.NewDecoder(file).Decode(v)
 }
 
-func loadFiles(store *content.FileStore, annotations map[string]map[string]string, opts *pushOptions) ([]ocispec.Descriptor, map[string]map[string]string, error) {
+func loadFiles(store *content.FileStore, annotations map[string]map[string]string, opts *pushOptions) ([]ocispec.Descriptor, error) {
 	var files []ocispec.Descriptor
 	for _, fileRef := range opts.fileRefs {
 		filename, mediaType := parseFileRef(fileRef, "")
@@ -155,7 +155,7 @@ func loadFiles(store *content.FileStore, annotations map[string]map[string]strin
 		}
 		file, err := store.Add(name, mediaType, filename)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		if annotations != nil {
 			if value, ok := annotations[filename]; ok {
@@ -170,7 +170,7 @@ func loadFiles(store *content.FileStore, annotations map[string]map[string]strin
 		}
 		files = append(files, file)
 	}
-	return files, annotations, nil
+	return files, nil
 }
 
 func pushStatusTrack() images.Handler {

--- a/cmd/oras/push.go
+++ b/cmd/oras/push.go
@@ -77,7 +77,7 @@ func runPush(opts pushOptions) error {
 	ctx := context.Background()
 	if opts.debug {
 		logrus.SetLevel(logrus.DebugLevel)
-	} else {
+	} else if !opts.verbose {
 		ctx = ctxo.WithLoggerDiscarded(ctx)
 	}
 
@@ -147,10 +147,9 @@ func runPush(opts pushOptions) error {
 		return err
 	}
 
-	if opts.verbose {
-		fmt.Println("Pushed", opts.targetRef)
-		fmt.Println(desc.Digest)
-	}
+	fmt.Println("Pushed", opts.targetRef)
+	fmt.Println("Digest:", desc.Digest)
+
 	return nil
 }
 

--- a/cmd/oras/push.go
+++ b/cmd/oras/push.go
@@ -120,7 +120,7 @@ func runPush(opts pushOptions) error {
 			name = filepath.ToSlash(name)
 		}
 		if opts.verbose {
-			fmt.Println(name)
+			fmt.Println("Preparing", name)
 		}
 		file, err := store.Add(name, mediaType, filename)
 		if err != nil {

--- a/pkg/oras/pull.go
+++ b/pkg/oras/pull.go
@@ -67,6 +67,7 @@ func fetchContent(ctx context.Context, fetcher remotes.Fetcher, desc ocispec.Des
 		picker,
 		images.ChildrenHandler(store),
 	)
+	handlers = append(handlers, opts.callbackHandlers...)
 
 	if err := opts.dispatch(ctx, images.Handlers(handlers...), desc); err != nil {
 		return nil, err

--- a/pkg/oras/pull_opts.go
+++ b/pkg/oras/pull_opts.go
@@ -11,6 +11,7 @@ type pullOpts struct {
 	allowedMediaTypes []string
 	dispatch          func(context.Context, images.Handler, ...ocispec.Descriptor) error
 	baseHandlers      []images.Handler
+	callbackHandlers  []images.Handler
 }
 
 // PullOpt allows callers to set options on the oras pull
@@ -49,6 +50,15 @@ func WithPullByBFS(o *pullOpts) error {
 func WithPullBaseHandler(handlers ...images.Handler) PullOpt {
 	return func(o *pullOpts) error {
 		o.baseHandlers = append(o.baseHandlers, handlers...)
+		return nil
+	}
+}
+
+// WithPullCallbackHandler provides callback handlers, which will be called after
+// any pull specific handlers.
+func WithPullCallbackHandler(handlers ...images.Handler) PullOpt {
+	return func(o *pullOpts) error {
+		o.callbackHandlers = append(o.callbackHandlers, handlers...)
 		return nil
 	}
 }


### PR DESCRIPTION
Enhance user experience on Push and Pull. Resolves #77.
```
$ oras push localhost:5000/club:party cake.txt juice.txt
Uploading be6fe1187628 juice.txt
Uploading 22af0898315a cake.txt
Pushed localhost:5000/club:party
Digest: sha256:5c46f904baecbd34f1a261e67200faed4bb0a904d152af3cdd7c9a57ac017998
$ oras pull localhost:5000/club:party
Downloaded be6fe1187628 juice.txt
Downloaded 22af0898315a cake.txt
Pulled localhost:5000/club:party
Digest: sha256:5c46f904baecbd34f1a261e67200faed4bb0a904d152af3cdd7c9a57ac017998
```

With verbose:
```
$ oras push -v localhost:5000/club:party cake.txt juice.txt
Preparing cake.txt
Preparing juice.txt
Uploading be6fe1187628 juice.txt
Uploading 22af0898315a cake.txt
Pushed localhost:5000/club:party
Digest: sha256:5c46f904baecbd34f1a261e67200faed4bb0a904d152af3cdd7c9a57ac017998
$ oras pull -v localhost:5000/club:party
WARN[0000] unknown type: application/vnd.oci.image.config.v1+json
Downloaded be6fe1187628 juice.txt
Downloaded 22af0898315a cake.txt
Pulled localhost:5000/club:party
Digest: sha256:5c46f904baecbd34f1a261e67200faed4bb0a904d152af3cdd7c9a57ac017998
```

Pushing / pulling without a tag is also allowed. Fixes #79.
```
$ oras push localhost:5000/club cake.txt juice.txt
Uploading be6fe1187628 juice.txt
Uploading 22af0898315a cake.txt
Pushed localhost:5000/club
Digest: sha256:5c46f904baecbd34f1a261e67200faed4bb0a904d152af3cdd7c9a57ac017998
$ oras pull localhost:5000/club@sha256:5c46f904baecbd34f1a261e67200faed4bb0a904d152af3cdd7c9a57ac017998
Downloaded be6fe1187628 juice.txt
Downloaded 22af0898315a cake.txt
Pulled localhost:5000/club@sha256:5c46f904baecbd34f1a261e67200faed4bb0a904d152af3cdd7c9a57ac017998
Digest: sha256:5c46f904baecbd34f1a261e67200faed4bb0a904d152af3cdd7c9a57ac017998
```

## Note
We are not able to know whether individual file is uploaded or not as it is limited by the stable version of `containerd` (v1.2.6) with detailed code at [here](https://github.com/containerd/containerd/blob/v1.2.6/remotes/handlers.go#L159). We can have a better UX in the next version of `oras` once `containerd` has new releases (their current master branch does not limit us).