### PR TITLE
New OCIStore

### DIFF
--- a/pkg/content/consts.go
+++ b/pkg/content/consts.go
@@ -20,3 +20,9 @@ const (
 	// AnnotationUnpack is the annotation key for indication of unpacking
 	AnnotationUnpack = "io.deis.oras.content.unpack"
 )
+
+const (
+	// OCIImageIndexFile is the file name of the index from the OCI Image Layout Specification
+	// Reference: https://github.com/opencontainers/image-spec/blob/master/image-layout.md#indexjson-file
+	OCIImageIndexFile = "index.json"
+)

--- a/pkg/content/errors.go
+++ b/pkg/content/errors.go
@@ -4,9 +4,10 @@ import "errors"
 
 // Common errors
 var (
-	ErrNotFound        = errors.New("not_found")
-	ErrNoName          = errors.New("no_name")
-	ErrUnsupportedSize = errors.New("unsupported_size")
+	ErrNotFound           = errors.New("not_found")
+	ErrNoName             = errors.New("no_name")
+	ErrUnsupportedSize    = errors.New("unsupported_size")
+	ErrUnsupportedVersion = errors.New("unsupported_version")
 )
 
 // FileStore errors

--- a/pkg/content/file.go
+++ b/pkg/content/file.go
@@ -20,8 +20,7 @@ import (
 
 // ensure interface
 var (
-	_ content.Provider = &FileStore{}
-	_ content.Ingester = &FileStore{}
+	_ ProvideIngester = &FileStore{}
 )
 
 // FileStore provides content from the file system

--- a/pkg/content/interface.go
+++ b/pkg/content/interface.go
@@ -1,0 +1,9 @@
+package content
+
+import "github.com/containerd/containerd/content"
+
+// ProvideIngester is the interface that groups the basic Read and Write methods.
+type ProvideIngester interface {
+	content.Provider
+	content.Ingester
+}

--- a/pkg/content/oci.go
+++ b/pkg/content/oci.go
@@ -68,11 +68,7 @@ func (s *OCIStore) LoadIndex() error {
 
 	s.nameMap = make(map[string]ocispec.Descriptor)
 	for _, desc := range s.index.Manifests {
-		if desc.Annotations == nil {
-			continue
-		}
-		name := desc.Annotations[ocispec.AnnotationRefName]
-		if name != "" {
+		if name := desc.Annotations[ocispec.AnnotationRefName]; name != "" {
 			s.nameMap[name] = desc
 		}
 	}
@@ -103,9 +99,6 @@ func (s *OCIStore) AddReference(name string, desc ocispec.Descriptor) {
 
 	if _, ok := s.nameMap[name]; ok {
 		for i, ref := range s.index.Manifests {
-			if ref.Annotations == nil {
-				continue
-			}
 			if name == ref.Annotations[ocispec.AnnotationRefName] {
 				s.index.Manifests[i] = desc
 				return
@@ -129,9 +122,6 @@ func (s *OCIStore) DeleteReference(name string) {
 
 	delete(s.nameMap, name)
 	for i, desc := range s.index.Manifests {
-		if desc.Annotations == nil {
-			continue
-		}
 		if name == desc.Annotations[ocispec.AnnotationRefName] {
 			s.index.Manifests[i] = s.index.Manifests[len(s.index.Manifests)-1]
 			s.index.Manifests = s.index.Manifests[:len(s.index.Manifests)-1]

--- a/pkg/content/oci.go
+++ b/pkg/content/oci.go
@@ -1,0 +1,96 @@
+package content
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/content/local"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// OCIStore provides content from the file system with the OCI-Image layout.
+// Reference: https://github.com/opencontainers/image-spec/blob/master/image-layout.md
+type OCIStore struct {
+	content.Store
+
+	root  string
+	index *ocispec.Index
+}
+
+// NewOCIStore creates a new OCI store
+func NewOCIStore(rootPath string) (*OCIStore, error) {
+	fileStore, err := local.NewStore(rootPath)
+	if err != nil {
+		return nil, err
+	}
+
+	store := &OCIStore{
+		Store: fileStore,
+		root:  rootPath,
+		index: &ocispec.Index{},
+	}
+	if err := store.validateOCILayoutFile(); err != nil {
+		return nil, err
+	}
+
+	return store, nil
+}
+
+// LoadIndex reads the index.json from the file system
+func (s *OCIStore) LoadIndex() error {
+	path := filepath.Join(s.root, OCIImageIndexFile)
+	indexFile, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer indexFile.Close()
+
+	return json.NewDecoder(indexFile).Decode(&s.index)
+}
+
+// SaveIndex writes the index.json to the file system
+func (s *OCIStore) SaveIndex() error {
+	indexJSON, err := json.Marshal(s.index)
+	if err != nil {
+		return err
+	}
+
+	path := filepath.Join(s.root, OCIImageIndexFile)
+	return ioutil.WriteFile(path, indexJSON, 0644)
+}
+
+// validateOCILayoutFile ensures the `oci-layout` file
+func (s *OCIStore) validateOCILayoutFile() error {
+	layoutFilePath := filepath.Join(s.root, ocispec.ImageLayoutFile)
+	layoutFile, err := os.Open(layoutFilePath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+
+		layout := ocispec.ImageLayout{
+			Version: ocispec.ImageLayoutVersion,
+		}
+		layoutJSON, err := json.Marshal(layout)
+		if err != nil {
+			return err
+		}
+
+		return ioutil.WriteFile(layoutFilePath, layoutJSON, 0644)
+	}
+	defer layoutFile.Close()
+
+	var layout *ocispec.ImageLayout
+	err = json.NewDecoder(layoutFile).Decode(&layout)
+	if err != nil {
+		return err
+	}
+	if layout.Version != ocispec.ImageLayoutVersion {
+		return ErrUnsupportedVersion
+	}
+
+	return nil
+}

--- a/pkg/oras/pull.go
+++ b/pkg/oras/pull.go
@@ -57,7 +57,11 @@ func fetchContent(ctx context.Context, fetcher remotes.Fetcher, desc ocispec.Des
 		}
 		return nil, nil
 	})
-	store := newHybridStoreFromIngester(ingester)
+
+	store := opts.contentProvideIngester
+	if store == nil {
+		store = newHybridStoreFromIngester(ingester)
+	}
 	handlers := []images.Handler{
 		filterHandler(opts.allowedMediaTypes...),
 	}

--- a/pkg/oras/pull.go
+++ b/pkg/oras/pull.go
@@ -48,7 +48,7 @@ func fetchContent(ctx context.Context, fetcher remotes.Fetcher, desc ocispec.Des
 	lock := &sync.Mutex{}
 	picker := images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 		if isAllowedMediaType(desc.MediaType, opts.allowedMediaTypes...) {
-			if name, ok := orascontent.ResolveName(desc); ok && len(name) > 0 {
+			if opts.filterName(desc) {
 				lock.Lock()
 				defer lock.Unlock()
 				descriptors = append(descriptors, desc)
@@ -63,7 +63,7 @@ func fetchContent(ctx context.Context, fetcher remotes.Fetcher, desc ocispec.Des
 		store = newHybridStoreFromIngester(ingester)
 	}
 	handlers := []images.Handler{
-		filterHandler(opts.allowedMediaTypes...),
+		filterHandler(opts, opts.allowedMediaTypes...),
 	}
 	handlers = append(handlers, opts.baseHandlers...)
 	handlers = append(handlers,
@@ -80,13 +80,13 @@ func fetchContent(ctx context.Context, fetcher remotes.Fetcher, desc ocispec.Des
 	return descriptors, nil
 }
 
-func filterHandler(allowedMediaTypes ...string) images.HandlerFunc {
+func filterHandler(opts *pullOpts, allowedMediaTypes ...string) images.HandlerFunc {
 	return func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 		switch {
 		case isAllowedMediaType(desc.MediaType, ocispec.MediaTypeImageManifest, ocispec.MediaTypeImageIndex):
 			return nil, nil
 		case isAllowedMediaType(desc.MediaType, allowedMediaTypes...):
-			if name, ok := orascontent.ResolveName(desc); ok && len(name) > 0 {
+			if opts.filterName(desc) {
 				return nil, nil
 			}
 			log.G(ctx).Warnf("blob no name: %v", desc.Digest)
@@ -126,4 +126,9 @@ func dispatchBFS(ctx context.Context, handler images.Handler, descs ...ocispec.D
 		descs = append(descs, children...)
 	}
 	return nil
+}
+
+func filterName(desc ocispec.Descriptor) bool {
+	name, ok := orascontent.ResolveName(desc)
+	return ok && len(name) > 0
 }

--- a/pkg/oras/pull_opts.go
+++ b/pkg/oras/pull_opts.go
@@ -15,6 +15,7 @@ type pullOpts struct {
 	baseHandlers           []images.Handler
 	callbackHandlers       []images.Handler
 	contentProvideIngester orascontent.ProvideIngester
+	filterName             func(ocispec.Descriptor) bool
 }
 
 // PullOpt allows callers to set options on the oras pull
@@ -22,7 +23,8 @@ type PullOpt func(o *pullOpts) error
 
 func pullOptsDefaults() *pullOpts {
 	return &pullOpts{
-		dispatch: images.Dispatch,
+		dispatch:   images.Dispatch,
+		filterName: filterName,
 	}
 }
 
@@ -71,6 +73,16 @@ func WithPullCallbackHandler(handlers ...images.Handler) PullOpt {
 func WithContentProvideIngester(store orascontent.ProvideIngester) PullOpt {
 	return func(o *pullOpts) error {
 		o.contentProvideIngester = store
+		return nil
+	}
+}
+
+// WithPullEmptyNameAllowed allows pulling blobs with empty name.
+func WithPullEmptyNameAllowed() PullOpt {
+	return func(o *pullOpts) error {
+		o.filterName = func(ocispec.Descriptor) bool {
+			return true
+		}
 		return nil
 	}
 }

--- a/pkg/oras/pull_opts.go
+++ b/pkg/oras/pull_opts.go
@@ -3,15 +3,18 @@ package oras
 import (
 	"context"
 
+	orascontent "github.com/deislabs/oras/pkg/content"
+
 	"github.com/containerd/containerd/images"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type pullOpts struct {
-	allowedMediaTypes []string
-	dispatch          func(context.Context, images.Handler, ...ocispec.Descriptor) error
-	baseHandlers      []images.Handler
-	callbackHandlers  []images.Handler
+	allowedMediaTypes      []string
+	dispatch               func(context.Context, images.Handler, ...ocispec.Descriptor) error
+	baseHandlers           []images.Handler
+	callbackHandlers       []images.Handler
+	contentProvideIngester orascontent.ProvideIngester
 }
 
 // PullOpt allows callers to set options on the oras pull
@@ -59,6 +62,15 @@ func WithPullBaseHandler(handlers ...images.Handler) PullOpt {
 func WithPullCallbackHandler(handlers ...images.Handler) PullOpt {
 	return func(o *pullOpts) error {
 		o.callbackHandlers = append(o.callbackHandlers, handlers...)
+		return nil
+	}
+}
+
+// WithContentProvideIngester opt to the provided Provider and Ingester
+// for file system I/O, including caches.
+func WithContentProvideIngester(store orascontent.ProvideIngester) PullOpt {
+	return func(o *pullOpts) error {
+		o.contentProvideIngester = store
 		return nil
 	}
 }


### PR DESCRIPTION
Resolves #107 

Example usage:
```go
func demo() error {
	ref := "localhost:5000/oras:test"
	ctx := context.Background()
	resolver := docker.NewResolver(docker.ResolverOptions{})

	store, err := content.NewOCIStore("store")
	if err != nil {
		return err
	}
	desc, _, err := oras.Pull(ctx, resolver, ref, nil,
		oras.WithContentProvideIngester(store),
		oras.WithPullEmptyNameAllowed(),
	)
	if err != nil {
		return err
	}

	store.AddReference(ref, desc)
	return store.SaveIndex()
}
```
It stores pulled content in the `store` folder as
```
store
├── blobs
│   └── sha256
│       ├── 03ba204e50d126e4674c005e04d82e84c21366780af1f43bd54a37816b6ab340
│       ├── 130c6b42d2ea0bbf0cc727aa2c2c193d1550e84b62202efbc1f24b5adddebd30
│       └── 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
├── index.json
├── ingest
└── oci-layout
```
where `ingest` is a folder generated by `containerd`.

The file contents are shown as follows:
- `oci-layout` after formatting:
```json
{
    "imageLayoutVersion": "1.0.0"
}
```
- `index.json` after formatting:
```json
{
    "schemaVersion": 2,
    "manifests": [
        {
            "mediaType": "application/vnd.oci.image.manifest.v1+json",
            "digest": "sha256:130c6b42d2ea0bbf0cc727aa2c2c193d1550e84b62202efbc1f24b5adddebd30",
            "size": 397,
            "annotations": {
                "org.opencontainers.image.ref.name": "localhost:5000/oras:test"
            }
        }
    ]
}
```
- The manifest `blobs/sha256/130c6b42d2ea0bbf0cc727aa2c2c193d1550e84b62202efbc1f24b5adddebd30` after formatting:
```json
{
    "schemaVersion": 2,
    "config": {
        "mediaType": "application/vnd.oci.image.config.v1+json",
        "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
        "size": 2
    },
    "layers": [
        {
            "mediaType": "application/vnd.oci.image.layer.v1.tar",
            "digest": "sha256:03ba204e50d126e4674c005e04d82e84c21366780af1f43bd54a37816b6ab340",
            "size": 13,
            "annotations": {
                "org.opencontainers.image.title": "hello.txt"
            }
        }
    ]
}
```
- The manifest config `blobs/sha256/44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`:
```json
{}
```
- The actual content `blobs/sha256/03ba204e50d126e4674c005e04d82e84c21366780af1f43bd54a37816b6ab340`:
```
Hello World!
```

---
The options
- `oras.WithContentProvideIngester(store)` allows pulling manifest or manifest index.
- `oras.WithPullEmptyNameAllowed()` allows pulling unnamed blobs.

If the option `oras.WithAllowedMediaType()` is not specified, setting both options basically dumps the remote image to the local file system. Try pull `docker.io/library/hello-world:latest` if interested.