### PR TITLE
Added unknown config mediaType

### DIFF
--- a/pkg/artifact/consts.go
+++ b/pkg/artifact/consts.go
@@ -1,0 +1,7 @@
+package artifact
+
+const (
+	// UnknownConfigMediaType is the default mediaType used when no
+	// config media type is specified.
+	UnknownConfigMediaType = "application/vnd.unknown.config.v1+json"
+)

--- a/pkg/oras/push.go
+++ b/pkg/oras/push.go
@@ -7,6 +7,7 @@ import (
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/remotes"
+	artifact "github.com/deislabs/oras/pkg/artifact"
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -66,7 +67,7 @@ func pack(provider content.Provider, descriptors []ocispec.Descriptor, opts *pus
 	if opts.config == nil {
 		configBytes := []byte("{}")
 		config = ocispec.Descriptor{
-			MediaType: ocispec.MediaTypeImageConfig,
+			MediaType: artifact.UnknownConfigMediaType,
 			Digest:    digest.FromBytes(configBytes),
 			Size:      int64(len(configBytes)),
 		}


### PR DESCRIPTION
Signed-off-by: Sajay Antony <sajaya@microsoft.com>

This addressed the config part of #115 
This PR fixes the default config media type as shown below 
```
{
  "schemaVersion": 2,
  "config": {
    "mediaType": "application/vnd.unknown.config.v1+json",
    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
    "size": 2
  },
  "layers": [
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar",
      "digest": "sha256:25748995a84fc5a1e85b53cd07dffc6e50e2cab1c34a49d9969f0f070d48468f",
      "size": 12912560,
      "annotations": {
        "org.opencontainers.image.title": "oras"
      }
    }
  ]
}
```