### PR TITLE
Add insecure and plain-http flag when pull and push

### DIFF
--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -26,10 +26,12 @@ type pullOptions struct {
 	output             string
 	verbose            bool
 
-	debug    bool
-	configs  []string
-	username string
-	password string
+	debug     bool
+	configs   []string
+	username  string
+	password  string
+	insecure  bool
+	plainHTTP bool
 }
 
 func pullCmd() *cobra.Command {
@@ -47,6 +49,12 @@ Example - Pull only files with the custom "application/vnd.me.hi" media type:
 
 Example - Pull all files, any media type:
   oras pull localhost:5000/hello:latest -a
+
+Example - Pull files from the insecure registry:
+  oras pull localhost:5000/hello:latest --insecure
+
+Example - Pull files from the HTTP registry:
+  oras pull localhost:5000/hello:latest --plain-http
 `,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -66,6 +74,8 @@ Example - Pull all files, any media type:
 	cmd.Flags().StringArrayVarP(&opts.configs, "config", "c", nil, "auth config path")
 	cmd.Flags().StringVarP(&opts.username, "username", "u", "", "registry username")
 	cmd.Flags().StringVarP(&opts.password, "password", "p", "", "registry password")
+	cmd.Flags().BoolVarP(&opts.insecure, "insecure", "", false, "allow connections to SSL registry without certs")
+	cmd.Flags().BoolVarP(&opts.plainHTTP, "plain-http", "", false, "use plain http and not https")
 	return cmd
 }
 
@@ -82,7 +92,7 @@ func runPull(opts pullOptions) error {
 		opts.allowedMediaTypes = []string{content.DefaultBlobMediaType, content.DefaultBlobDirMediaType}
 	}
 
-	resolver := newResolver(opts.username, opts.password, opts.configs...)
+	resolver := newResolver(opts.username, opts.password, opts.insecure, opts.plainHTTP, opts.configs...)
 	store := content.NewFileStore(opts.output)
 	defer store.Close()
 	store.DisableOverwrite = opts.keepOldFiles

--- a/pkg/auth/client.go
+++ b/pkg/auth/client.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	"github.com/containerd/containerd/remotes"
 )
@@ -19,5 +20,5 @@ type Client interface {
 	// Logout logs out from a remote server identified by the hostname.
 	Logout(ctx context.Context, hostname string) error
 	// Resolver returns a new authenticated resolver.
-	Resolver(ctx context.Context) (remotes.Resolver, error)
+	Resolver(ctx context.Context, client *http.Client, plainHTTP bool) (remotes.Resolver, error)
 }

--- a/pkg/auth/docker/resolver.go
+++ b/pkg/auth/docker/resolver.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
@@ -10,9 +11,11 @@ import (
 )
 
 // Resolver returns a new authenticated resolver.
-func (c *Client) Resolver(_ context.Context) (remotes.Resolver, error) {
+func (c *Client) Resolver(_ context.Context, client *http.Client, plainHTTP bool) (remotes.Resolver, error) {
 	return docker.NewResolver(docker.ResolverOptions{
 		Credentials: c.Credential,
+		Client:      client,
+		PlainHTTP:   plainHTTP,
 	}), nil
 }
 


### PR DESCRIPTION
This is the first commit about pull/push to an insecure registry.  

This PR implement pull or push to an insecure registry using the CNAME, but using the ip address is wrong. So this PR setting WIP. 

If someone know why, please tell me, thanks.

TODO:
- [x] pull/push to an insecure registry using the ip address, such as `192.168.100.20:8443`.
- [x] add `--plain-http` to pull or push a HTTP registry.

Related issue:
- https://github.com/helm/helm/issues/6324