### PR TITLE
Allow overriding the ManifestDescriptor when pushing

### DIFF
--- a/pkg/oras/push.go
+++ b/pkg/oras/push.go
@@ -83,6 +83,10 @@ func pack(provider content.Provider, descriptors []ocispec.Descriptor, opts *pus
 	}
 
 	// Manifest
+	if opts.manifest != nil {
+		return *opts.manifest, store, nil
+	}
+
 	manifest := ocispec.Manifest{
 		Versioned: specs.Versioned{
 			SchemaVersion: 2, // historical value. does not pertain to OCI or docker version

--- a/pkg/oras/push_opts.go
+++ b/pkg/oras/push_opts.go
@@ -15,6 +15,7 @@ type pushOpts struct {
 	config              *ocispec.Descriptor
 	configMediaType     string
 	configAnnotations   map[string]string
+	manifest            *ocispec.Descriptor
 	manifestAnnotations map[string]string
 	validateName        func(desc ocispec.Descriptor) error
 	baseHandlers        []images.Handler
@@ -29,7 +30,7 @@ func pushOptsDefaults() *pushOpts {
 // PushOpt allows callers to set options on the oras push
 type PushOpt func(o *pushOpts) error
 
-// WithConfig overrides the config
+// WithConfig overrides the config - setting this will ignore WithConfigMediaType and WithConfigAnnotations
 func WithConfig(config ocispec.Descriptor) PushOpt {
 	return func(o *pushOpts) error {
 		o.config = &config
@@ -49,6 +50,14 @@ func WithConfigMediaType(mediaType string) PushOpt {
 func WithConfigAnnotations(annotations map[string]string) PushOpt {
 	return func(o *pushOpts) error {
 		o.configAnnotations = annotations
+		return nil
+	}
+}
+
+// WithManifest overrides the manifest - setting this will ignore WithManifestConfigAnnotations
+func WithManifest(manifest ocispec.Descriptor) PushOpt {
+	return func(o *pushOpts) error {
+		o.manifest = &manifest
 		return nil
 	}
 }


### PR DESCRIPTION
**What this does**
This PR adds a new field to `PushOpt`, and corresponding config functions, to allow giving an entire manifest descriptor to ORAS when pushing.

**Why**

I've been experimenting with building small, static images using ORAS, while still making them appear as standard docker v2-2 images rather than OCI. 

I found that I could do almost everything I needed to aside from overriding the ManifestDescriptor - which I needed to do to set the MediaType on the manifest (`image-spec` omits this field, but docker registry complains about it).

See where I'm using this here: https://github.com/ecordell/bndlr/blob/master/pkg/bundle/bundle.go#L58-L79

Also open to feedback and suggestions if there are better approaches to what I'm doing. Thanks!