### PR TITLE
Allow empty artifact

### DIFF
--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -98,7 +98,7 @@ func runPull(opts pullOptions) error {
 	store.DisableOverwrite = opts.keepOldFiles
 	store.AllowPathTraversalOnWrite = opts.pathTraversal
 
-	desc, _, err := oras.Pull(ctx, resolver, opts.targetRef, store,
+	desc, artifacts, err := oras.Pull(ctx, resolver, opts.targetRef, store,
 		oras.WithAllowedMediaTypes(opts.allowedMediaTypes),
 		oras.WithPullCallbackHandler(pullStatusTrack()),
 	)
@@ -107,6 +107,9 @@ func runPull(opts pullOptions) error {
 			return fmt.Errorf("image reference format is invalid. Please specify <name:tag|name@digest>")
 		}
 		return err
+	}
+	if len(artifacts) == 0 {
+		fmt.Println("Downloaded empty artifact")
 	}
 	fmt.Println("Pulled", opts.targetRef)
 	fmt.Println("Digest:", desc.Digest)

--- a/cmd/oras/push.go
+++ b/cmd/oras/push.go
@@ -64,7 +64,7 @@ Example - Push file to the insecure registry:
 Example - Push file to the HTTP registry:
   oras push localhost:5000/hello:latest hi.txt --plain-http
 `,
-		Args: cobra.MinimumNArgs(2),
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.targetRef = args[0]
 			opts.fileRefs = args[1:]
@@ -126,6 +126,9 @@ func runPush(opts pushOptions) error {
 	files, err := loadFiles(store, annotations, &opts)
 	if err != nil {
 		return err
+	}
+	if len(files) == 0 {
+		fmt.Println("Uploading empty artifact")
 	}
 
 	// ready to push

--- a/pkg/oras/errors.go
+++ b/pkg/oras/errors.go
@@ -8,7 +8,6 @@ import (
 // Common errors
 var (
 	ErrResolverUndefined = errors.New("resolver undefined")
-	ErrEmptyDescriptors  = errors.New("empty descriptors")
 )
 
 // Path validation related errors

--- a/pkg/oras/oras_test.go
+++ b/pkg/oras/oras_test.go
@@ -84,7 +84,7 @@ func (suite *ORASTestSuite) Test_0_Push() {
 
 	ref = fmt.Sprintf("%s/empty:test", suite.DockerRegistryHost)
 	_, err = Push(newContext(), newResolver(), ref, nil, descriptors)
-	suite.NotNil(ErrEmptyDescriptors, err, "error pushing with empty descriptors")
+	suite.Nil(err, "no error pushing with empty descriptors")
 
 	// Load descriptors with test chart tgz (as single layer)
 	store = orascontent.NewFileStore("")

--- a/pkg/oras/push.go
+++ b/pkg/oras/push.go
@@ -85,7 +85,7 @@ func pack(provider content.Provider, descriptors []ocispec.Descriptor, opts *pus
 	}
 
 	if descriptors == nil {
-		descriptors = []ocispec.Descriptor{} // make it an empty array to avoid potential server-side bugs
+		descriptors = []ocispec.Descriptor{} // make it an empty array to prevent potential server-side bugs
 	}
 	manifest := ocispec.Manifest{
 		Versioned: specs.Versioned{

--- a/pkg/oras/push.go
+++ b/pkg/oras/push.go
@@ -18,9 +18,6 @@ func Push(ctx context.Context, resolver remotes.Resolver, ref string, provider c
 	if resolver == nil {
 		return ocispec.Descriptor{}, ErrResolverUndefined
 	}
-	if len(descriptors) == 0 {
-		return ocispec.Descriptor{}, ErrEmptyDescriptors
-	}
 	opt := pushOptsDefaults()
 	for _, o := range opts {
 		if err := o(opt); err != nil {
@@ -87,6 +84,9 @@ func pack(provider content.Provider, descriptors []ocispec.Descriptor, opts *pus
 		return *opts.manifest, store, nil
 	}
 
+	if descriptors == nil {
+		descriptors = []ocispec.Descriptor{} // make it an empty array to avoid potential server-side bugs
+	}
 	manifest := ocispec.Manifest{
 		Versioned: specs.Versioned{
 			SchemaVersion: 2, // historical value. does not pertain to OCI or docker version


### PR DESCRIPTION
Allow oras to push or pull empty artifact, which has no layers but a config.

CLI experience is shown as follows.
- on push:
```
PS C:\> oras push shizhtest.azurecr.io/oras/empty:latest
Uploading empty artifact
Pushed shizhtest.azurecr.io/oras/empty:latest
Digest: sha256:bc4b23b58840b73e24d7be3ff6baa477a830999023af4c75c83ec4db6c86fc9a
```
- on pull:
```
PS C:\> oras pull shizhtest.azurecr.io/oras/empty:latest
Downloaded empty artifact
Pulled shizhtest.azurecr.io/oras/empty:latest
Digest: sha256:bc4b23b58840b73e24d7be3ff6baa477a830999023af4c75c83ec4db6c86fc9a
```

Resolves #153 