### PR TITLE
Refactor docker/NewClient to use early return

### DIFF
--- a/pkg/auth/docker/client.go
+++ b/pkg/auth/docker/client.go
@@ -22,13 +22,6 @@ type Client struct {
 // All changes will only be written to the first config file.
 func NewClient(configPaths ...string) (auth.Client, error) {
 	var configs []*configfile.ConfigFile
-	for _, path := range configPaths {
-		cfg, err := loadConfigFile(path)
-		if err != nil {
-			return nil, errors.Wrap(err, path)
-		}
-		configs = append(configs, cfg)
-	}
 	if len(configs) == 0 {
 		cfg, err := config.Load(config.Dir())
 		if err != nil {
@@ -37,7 +30,18 @@ func NewClient(configPaths ...string) (auth.Client, error) {
 		if !cfg.ContainsAuth() {
 			cfg.CredentialsStore = credentials.DetectDefaultStore(cfg.CredentialsStore)
 		}
-		configs = []*configfile.ConfigFile{cfg}
+
+		return &Client{
+			configs: []*configfile.ConfigFile{cfg},
+		}, nil
+	}
+
+	for _, path := range configPaths {
+		cfg, err := loadConfigFile(path)
+		if err != nil {
+			return nil, errors.Wrap(err, path)
+		}
+		configs = append(configs, cfg)
 	}
 
 	return &Client{

--- a/pkg/auth/docker/client.go
+++ b/pkg/auth/docker/client.go
@@ -21,7 +21,6 @@ type Client struct {
 // Credentials are read from the first config and fall backs to next.
 // All changes will only be written to the first config file.
 func NewClient(configPaths ...string) (auth.Client, error) {
-	var configs []*configfile.ConfigFile
 	if len(configPaths) == 0 {
 		cfg, err := config.Load(config.Dir())
 		if err != nil {
@@ -36,6 +35,7 @@ func NewClient(configPaths ...string) (auth.Client, error) {
 		}, nil
 	}
 
+	var configs []*configfile.ConfigFile
 	for _, path := range configPaths {
 		cfg, err := loadConfigFile(path)
 		if err != nil {

--- a/pkg/auth/docker/client.go
+++ b/pkg/auth/docker/client.go
@@ -22,7 +22,7 @@ type Client struct {
 // All changes will only be written to the first config file.
 func NewClient(configPaths ...string) (auth.Client, error) {
 	var configs []*configfile.ConfigFile
-	if len(configs) == 0 {
+	if len(configPaths) == 0 {
 		cfg, err := config.Load(config.Dir())
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## What

As title.

## Why

For better code. Before `for`-looping, IMO, it is better to check the length and early return if the length is zero.