### PR TITLE
Fix `pkg/auth/docker` test

### DIFF
--- a/pkg/auth/docker/client_test.go
+++ b/pkg/auth/docker/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -75,6 +76,23 @@ func (suite *DockerClientTestSuite) SetupSuite() {
 
 	// Start Docker registry
 	go dockerRegistry.ListenAndServe()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+	for {
+		select {
+		case <-ctx.Done():
+			suite.FailNow("docker registry timed out")
+		default:
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://%s/v2/", suite.DockerRegistryHost), nil)
+		suite.Nil(err, "no error in generate a /v2/ request")
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			resp.Body.Close()
+			break
+		}
+		time.Sleep(time.Second)
+	}
 }
 
 func (suite *DockerClientTestSuite) TearDownSuite() {

--- a/pkg/auth/docker/client_test.go
+++ b/pkg/auth/docker/client_test.go
@@ -84,7 +84,12 @@ func (suite *DockerClientTestSuite) SetupSuite() {
 			suite.FailNow("docker registry timed out")
 		default:
 		}
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://%s/v2/", suite.DockerRegistryHost), nil)
+		req, err := http.NewRequestWithContext(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("http://%s/v2/", suite.DockerRegistryHost),
+			nil,
+		)
 		suite.Nil(err, "no error in generate a /v2/ request")
 		resp, err := http.DefaultClient.Do(req)
 		if err == nil {


### PR DESCRIPTION
Fix build failure due to errors in `pkg/auth/docker/client_test.go`. The root cause is that the test registry may not be running before any test cases.