### PR TITLE
multiwriteringester support

### DIFF
--- a/pkg/content/decompressstore.go
+++ b/pkg/content/decompressstore.go
@@ -2,12 +2,13 @@ package content
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	ctrcontent "github.com/containerd/containerd/content"
 )
 
-// DecompressWriter store to decompress content and extract from tar, if needed, wrapping
+// DecompressStore store to decompress content and extract from tar, if needed, wrapping
 // another store. By default, a FileStore will simply take each artifact and write it to
 // a file, as a MemoryStore will do into memory. If the artifact is gzipped or tarred,
 // you might want to store the actual object inside tar or gzip. Wrap your Store
@@ -17,15 +18,34 @@ import (
 // For example:
 //
 //        fileStore := NewFileStore(rootPath)
-//        decompressStore := store.NewDecompressStore(fileStore, blocksize)
+//        decompressStore := store.NewDecompressStore(fileStore, WithBlocksize(blocksize))
+//
+// The above example works if there is no tar, i.e. each artifact is just a single file, perhaps gzipped,
+// or if there is only one file in each tar archive. In other words, when each content.Writer has only one target output stream.
+// However, if you have multiple files in each tar archive, each archive of which is an artifact layer, then
+// you need a way to select how to handle each file in the tar archive. In other words, when each content.Writer has more than one
+// target output stream. In that case, use the following example:
+//
+//        multiStore := NewMultiStore(rootPath) // some store that can handle different filenames
+//        decompressStore := store.NewDecompressStore(multiStore, WithBlocksize(blocksize), WithMultiWriterIngester())
 //
 type DecompressStore struct {
-	ingester  ctrcontent.Ingester
-	blocksize int
+	ingester            ctrcontent.Ingester
+	blocksize           int
+	multiWriterIngester bool
 }
 
-func NewDecompressStore(ingester ctrcontent.Ingester, blocksize int) DecompressStore {
-	return DecompressStore{ingester, blocksize}
+func NewDecompressStore(ingester ctrcontent.Ingester, opts ...WriterOpt) DecompressStore {
+	// we have to reprocess the opts to find the blocksize
+	var wOpts WriterOpts
+	for _, opt := range opts {
+		if err := opt(&wOpts); err != nil {
+			// TODO: we probably should handle errors here
+			continue
+		}
+	}
+
+	return DecompressStore{ingester, wOpts.Blocksize, wOpts.MultiWriterIngester}
 }
 
 // Writer get a writer
@@ -34,9 +54,19 @@ func (d DecompressStore) Writer(ctx context.Context, opts ...ctrcontent.WriterOp
 	// - if there is a desc in the opts, and the mediatype is tar or tar+gzip, then pass the correct decompress writer
 	// - else, pass the regular writer
 	var (
-		writer ctrcontent.Writer
-		err    error
+		writer        ctrcontent.Writer
+		err           error
+		multiIngester MultiWriterIngester
+		ok            bool
 	)
+
+	// check to see if we are supposed to use a MultiWriterIngester
+	if d.multiWriterIngester {
+		multiIngester, ok = d.ingester.(MultiWriterIngester)
+		if !ok {
+			return nil, errors.New("configured to use multiwriter ingester, but ingester does not implement multiwriter")
+		}
+	}
 
 	// we have to reprocess the opts to find the desc
 	var wOpts ctrcontent.WriterOpts
@@ -52,20 +82,37 @@ func (d DecompressStore) Writer(ctx context.Context, opts ...ctrcontent.WriterOp
 	hasGzip, hasTar, modifiedMediaType := checkCompression(desc.MediaType)
 	wOpts.Desc.MediaType = modifiedMediaType
 	opts = append(opts, ctrcontent.WithDescriptor(wOpts.Desc))
-	writer, err = d.ingester.Writer(ctx, opts...)
-	if err != nil {
-		return nil, err
-	}
 	// determine if we pass it blocksize, only if positive
 	writerOpts := []WriterOpt{}
 	if d.blocksize > 0 {
 		writerOpts = append(writerOpts, WithBlocksize(d.blocksize))
 	}
-	// figure out which writer we need
+
+	writer, err = d.ingester.Writer(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// do we need to wrap with an untar writer?
 	if hasTar {
-		writer = NewUntarWriter(writer, writerOpts...)
+		// if not multiingester, get a regular writer
+		if multiIngester == nil {
+			writer = NewUntarWriter(writer, writerOpts...)
+		} else {
+			writers, err := multiIngester.Writers(ctx, opts...)
+			if err != nil {
+				return nil, err
+			}
+			writer = NewUntarWriterByName(writers, writerOpts...)
+		}
 	}
 	if hasGzip {
+		if writer == nil {
+			writer, err = d.ingester.Writer(ctx, opts...)
+			if err != nil {
+				return nil, err
+			}
+		}
 		writer = NewGunzipWriter(writer, writerOpts...)
 	}
 	return writer, nil

--- a/pkg/content/decompressstore_test.go
+++ b/pkg/content/decompressstore_test.go
@@ -32,7 +32,7 @@ func TestDecompressStore(t *testing.T) {
 	}
 
 	memStore := content.NewMemoryStore()
-	decompressStore := content.NewDecompressStore(memStore, 0)
+	decompressStore := content.NewDecompressStore(memStore, content.WithBlocksize(0))
 	ctx := context.Background()
 	decompressWriter, err := decompressStore.Writer(ctx, ctrcontent.WithDescriptor(gzipDescriptor))
 	if err != nil {

--- a/pkg/content/multiwriter.go
+++ b/pkg/content/multiwriter.go
@@ -1,0 +1,16 @@
+package content
+
+import (
+	"context"
+
+	ctrcontent "github.com/containerd/containerd/content"
+)
+
+// MultiWriterIngester an ingester that can provide a single writer or multiple writers for a single
+// descriptor. Useful when the target of a descriptor can have multiple items within it, e.g. a layer
+// that is a tar file with multiple files, each of which should go to a different stream, some of which
+// should not be handled at all
+type MultiWriterIngester interface {
+	ctrcontent.Ingester
+	Writers(ctx context.Context, opts ...ctrcontent.WriterOpt) (map[string]ctrcontent.Writer, error)
+}

--- a/pkg/content/opts.go
+++ b/pkg/content/opts.go
@@ -7,9 +7,10 @@ import (
 )
 
 type WriterOpts struct {
-	InputHash  *digest.Digest
-	OutputHash *digest.Digest
-	Blocksize  int
+	InputHash           *digest.Digest
+	OutputHash          *digest.Digest
+	Blocksize           int
+	MultiWriterIngester bool
 }
 
 type WriterOpt func(*WriterOpts) error
@@ -57,6 +58,16 @@ func WithBlocksize(blocksize int) WriterOpt {
 			return errors.New("blocksize must be greater than or equal to 0")
 		}
 		w.Blocksize = blocksize
+		return nil
+	}
+}
+
+// WithMultiWriterIngester the passed ingester also implements MultiWriter
+// and should be used as such. If this is set to true, but the ingester does not
+// implement MultiWriter, calling Writer should return an error.
+func WithMultiWriterIngester() WriterOpt {
+	return func(w *WriterOpts) error {
+		w.MultiWriterIngester = true
 		return nil
 	}
 }

--- a/pkg/content/untar.go
+++ b/pkg/content/untar.go
@@ -70,3 +70,83 @@ func NewUntarWriter(writer content.Writer, opts ...WriterOpt) content.Writer {
 		done <- err
 	}, opts...)
 }
+
+// NewUntarWriterByName wrap multiple writers with an untar, so that the stream is untarred and passed
+// to the appropriate writer, based on the filename. If a filename is not found, it will not pass it
+// to any writer. The filename "" will handle any stream that does not have a specific filename; use
+// it for the default of a single file in a tar stream.
+func NewUntarWriterByName(writers map[string]content.Writer, opts ...WriterOpt) content.Writer {
+	// process opts for default
+	wOpts := DefaultWriterOpts()
+	for _, opt := range opts {
+		if err := opt(&wOpts); err != nil {
+			return nil
+		}
+	}
+
+	// construct an array of content.Writer
+	nameToIndex := map[string]int{}
+	var writerSlice []content.Writer
+	for name, writer := range writers {
+		writerSlice = append(writerSlice, writer)
+		nameToIndex[name] = len(writerSlice) - 1
+	}
+	// need a PassthroughMultiWriter here
+	return NewPassthroughMultiWriter(writerSlice, func(r io.Reader, ws []io.Writer, done chan<- error) {
+		tr := tar.NewReader(r)
+		var err error
+		for {
+			header, err := tr.Next()
+			if err == io.EOF {
+				// clear the error, since we do not pass an io.EOF
+				err = nil
+				break // End of archive
+			}
+			if err != nil {
+				// pass the error on
+				err = fmt.Errorf("UntarWriter tar file header read error: %v", err)
+				break
+			}
+			// get the filename
+			filename := header.Name
+			index, ok := nameToIndex[filename]
+			if !ok {
+				index, ok = nameToIndex[""]
+				if !ok {
+					// we did not find this file or the wildcard, so do not process this file
+					continue
+				}
+			}
+
+			// write out the untarred data
+			// we can handle io.EOF, just go to the next file
+			// any other errors should stop and get reported
+			b := make([]byte, wOpts.Blocksize, wOpts.Blocksize)
+			for {
+				var n int
+				n, err = tr.Read(b)
+				if err != nil && err != io.EOF {
+					err = fmt.Errorf("UntarWriter file data read error: %v\n", err)
+					break
+				}
+				l := n
+				if n > len(b) {
+					l = len(b)
+				}
+				if _, err2 := ws[index].Write(b[:l]); err2 != nil {
+					err = fmt.Errorf("UntarWriter error writing to underlying writer at index %d for name '%s': %v", index, filename, err2)
+					break
+				}
+				if err == io.EOF {
+					// go to the next file
+					break
+				}
+			}
+			// did we break with a non-nil and non-EOF error?
+			if err != nil && err != io.EOF {
+				break
+			}
+		}
+		done <- err
+	}, opts...)
+}


### PR DESCRIPTION
This is a first cut attempt at this. It needs proper tests, which I am willing to add once we have agreement on the idea.

@jdolitsky this is what we discussed over Slack.

## Problem

The [DecompressStore](https://github.com/deislabs/oras/blob/0bffdbc8b717fdf774259c96f7ac285089f8ceaa/pkg/content/decompressstore.go#L22) has support for determining that a particular blob is tarred and then untarring it. This is great, but it assumes that the tar contains only one file. It even [ignores the filename](https://github.com/deislabs/oras/blob/0bffdbc8b717fdf774259c96f7ac285089f8ceaa/pkg/content/untar.go#L30-L35):

```go
			_, err := tr.Next()
			if err == io.EOF {
				// clear the error, since we do not pass an io.EOF
				err = nil
				break // End of archive
			}
```

One could argue about whether we should or should not support tar with multiple files in it, but as long as tar supports it, people _will_ use it, break this, and we will have issues.

The heart of the issue is that the standards assume one writer per descriptor. But if a descriptor references a tar file (or any other archiving format, but really only tar is used), then it might need multiple writers.

## Solution

This PR is a proposed solution. It creates two kinds of "untar writer" - one that has a single writer passed through, and another that has a "multi-writer" passed through. The multi-writer creates multiple writers, one for each filename, and untarwriter picks which one based on the filename.

It continues to have a regular `Writer`, so that non-tar layers can be handled.

The usage would be something like:

```go
        multiStore := NewMultiStore(rootPath) // some store that can handle different filenames
        decompressStore := store.NewDecompressStore(multiStore, WithBlocksize(blocksize), WithMultiWriterIngester())
```

where `multiStore` implements `MultiWriterIngester`:

```go
type MultiWriterIngester interface {
	ctrcontent.Ingester
	Writers(ctx context.Context, opts ...ctrcontent.WriterOpt) (map[string]ctrcontent.Writer, error)
}
```

Calling `.Writers()` returns a map of filename to `content.Writer`, which is passed to `UntarWriter`, which uses the appropriate one.

## Alternate

I did consider an alternate approach, one where, instead of returning `map[string]Writer`, it returned a func that can be called to get the writer:

```go
	Writers(ctx context.Context, opts ...ctrcontent.WriterOpt) (func (filename string) ctrcontent.Writer, error)
```

But I honestly couldn't see how the complexity added value. 

Looking forward to feedback.