### PR TITLE
Fix OCIStore inconsistent state after AddReference

### DIFF
--- a/pkg/content/oci.go
+++ b/pkg/content/oci.go
@@ -98,6 +98,8 @@ func (s *OCIStore) AddReference(name string, desc ocispec.Descriptor) {
 	}
 
 	if _, ok := s.nameMap[name]; ok {
+		s.nameMap[name] = desc
+
 		for i, ref := range s.index.Manifests {
 			if name == ref.Annotations[ocispec.AnnotationRefName] {
 				s.index.Manifests[i] = desc
@@ -107,11 +109,12 @@ func (s *OCIStore) AddReference(name string, desc ocispec.Descriptor) {
 
 		// Process should not reach here.
 		// Fallthrough to `Add` scenario and recover.
+		s.index.Manifests = append(s.index.Manifests, desc)
+		return
 	}
 
 	s.index.Manifests = append(s.index.Manifests, desc)
 	s.nameMap[name] = desc
-	return
 }
 
 // DeleteReference deletes an reference from index.


### PR DESCRIPTION
Update descriptor in the nameMap as well as in index.Manifests.

nameMap used in the ListReferences operation and should return actual descriptor.