### PR TITLE
actual versions in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/deislabs/oras
 go 1.15
 
 replace (
+	// WARNING! Do NOT replace these without also replacing their lines in the `require` stanza below.
+	// These `replace` stanzas are IGNORED when this is imported as a library
 	github.com/docker/distribution => github.com/docker/distribution v0.0.0-20191216044856-a8371794149d
 	github.com/docker/docker => github.com/moby/moby v17.12.0-ce-rc1.0.20200618181300-9dc6525e6118+incompatible
 )
@@ -14,8 +16,8 @@ require (
 	github.com/containerd/containerd v1.4.3
 	github.com/containerd/continuity v0.0.0-20201208142359-180525291bb7 // indirect
 	github.com/docker/cli v20.10.3+incompatible
-	github.com/docker/distribution v0.0.0-00010101000000-000000000000
-	github.com/docker/docker v0.0.0-00010101000000-000000000000
+	github.com/docker/distribution v0.0.0-20191216044856-a8371794149d
+	github.com/docker/docker v17.12.0-ce-rc1.0.20200618181300-9dc6525e6118+incompatible
 	github.com/docker/docker-credential-helpers v0.6.3 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect


### PR DESCRIPTION
Because `replace` directive is ignored when this is used as a library import. 