### PR TITLE
use function instead of static map

### DIFF
--- a/pkg/content/multiwriter.go
+++ b/pkg/content/multiwriter.go
@@ -9,8 +9,8 @@ import (
 // MultiWriterIngester an ingester that can provide a single writer or multiple writers for a single
 // descriptor. Useful when the target of a descriptor can have multiple items within it, e.g. a layer
 // that is a tar file with multiple files, each of which should go to a different stream, some of which
-// should not be handled at all
+// should not be handled at all.
 type MultiWriterIngester interface {
 	ctrcontent.Ingester
-	Writers(ctx context.Context, opts ...ctrcontent.WriterOpt) (map[string]ctrcontent.Writer, error)
+	Writers(ctx context.Context, opts ...ctrcontent.WriterOpt) (func(string) (ctrcontent.Writer, error), error)
 }

--- a/pkg/content/passthrough_test.go
+++ b/pkg/content/passthrough_test.go
@@ -1,9 +1,11 @@
 package content_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
+	"math/rand"
 	"testing"
 
 	ctrcontent "github.com/containerd/containerd/content"
@@ -113,5 +115,79 @@ func TestPassthroughWriter(t *testing.T) {
 		if string(b) != modifiedContent {
 			t.Errorf("mismatched content, expected '%s', got '%s'", modifiedContent, string(b))
 		}
+	}
+}
+
+func TestPassthroughMultiWriter(t *testing.T) {
+	// pass through function that selects one of two outputs
+	var (
+		b1, b2       bytes.Buffer
+		name1, name2 = "I am name 01", "I am name 02" // each of these is 12 bytes
+		data1, data2 = make([]byte, 500), make([]byte, 500)
+	)
+	rand.Read(data1)
+	rand.Read(data2)
+	combined := append([]byte(name1), data1...)
+	combined = append(combined, []byte(name2)...)
+	combined = append(combined, data2...)
+	f := func(r io.Reader, getwriter func(name string) io.Writer, done chan<- error) {
+		var (
+			err error
+		)
+		// test is done rather simply, with a single 1024 byte chunk, split into 2x512 data streams, each of which is
+		// 12 bytes of name and 500 bytes of data
+		b := make([]byte, 1024)
+		_, err = r.Read(b)
+		if err != nil && err != io.EOF {
+			t.Fatalf("data read error: %v", err)
+		}
+
+		// get the names and data for each
+		n1, n2 := string(b[0:12]), string(b[512+0:512+12])
+		w1, w2 := getwriter(n1), getwriter(n2)
+		if _, err := w1.Write(b[12:512]); err != nil {
+			t.Fatalf("w1 write error: %v", err)
+		}
+		if _, err := w2.Write(b[512+12 : 1024]); err != nil {
+			t.Fatalf("w2 write error: %v", err)
+		}
+		done <- err
+	}
+
+	var (
+		opts = []content.WriterOpt{content.WithInputHash(testContentHash), content.WithOutputHash(modifiedContentHash)}
+		hash = testContentHash
+	)
+	ctx := context.Background()
+	writers := func(name string) (ctrcontent.Writer, error) {
+		switch name {
+		case name1:
+			return content.NewIoContentWriter(&b1), nil
+		case name2:
+			return content.NewIoContentWriter(&b2), nil
+		}
+		return nil, fmt.Errorf("unknown name %s", name)
+	}
+	writer := content.NewPassthroughMultiWriter(writers, f, opts...)
+	n, err := writer.Write(combined)
+	if err != nil {
+		t.Fatalf("unexpected error on Write: %v", err)
+	}
+	if n != len(combined) {
+		t.Fatalf("wrote %d bytes instead of %d", n, len(combined))
+	}
+	if err := writer.Commit(ctx, testDescriptor.Size, hash); err != nil {
+		t.Errorf("unexpected error on Commit: %v", err)
+	}
+	if digest := writer.Digest(); digest != hash {
+		t.Errorf("mismatched digest: actual %v, expected %v", digest, hash)
+	}
+
+	// make sure the data is what we expected
+	if !bytes.Equal(data1, b1.Bytes()) {
+		t.Errorf("b1 data1 did not match")
+	}
+	if !bytes.Equal(data2, b2.Bytes()) {
+		t.Errorf("b2 data2 did not match")
 	}
 }


### PR DESCRIPTION
The multiwriter passed a `map[string]content.Writer`. The problem is that the thing that creates these writers sometimes doesn't know what writer it will use until later. This changes it to a func, so that it can determine it on the fly. The net result is the same, with some more flexibility.

Discussed on slack with @jdolitsky 

I still have some work to do to be sure this is ready, but the initial view can get looked at.