### PR TITLE
handle different gzip extensions

### DIFF
--- a/pkg/content/decompressstore.go
+++ b/pkg/content/decompressstore.go
@@ -124,11 +124,17 @@ func (d DecompressStore) Writer(ctx context.Context, opts ...ctrcontent.WriterOp
 func checkCompression(mediaType string) (gzip, tar bool, mt string) {
 	mt = mediaType
 	gzipSuffix := "+gzip"
+	gzipAltSuffix := ".gzip"
 	tarSuffix := ".tar"
-	if strings.HasSuffix(mt, gzipSuffix) {
+	switch {
+	case strings.HasSuffix(mt, gzipSuffix):
 		mt = mt[:len(mt)-len(gzipSuffix)]
 		gzip = true
+	case strings.HasSuffix(mt, gzipAltSuffix):
+		mt = mt[:len(mt)-len(gzipAltSuffix)]
+		gzip = true
 	}
+
 	if strings.HasSuffix(mt, tarSuffix) {
 		mt = mt[:len(mt)-len(tarSuffix)]
 		tar = true

--- a/pkg/content/decompressstore_test.go
+++ b/pkg/content/decompressstore_test.go
@@ -25,36 +25,40 @@ func TestDecompressStore(t *testing.T) {
 	}
 	gzipContent := buf.Bytes()
 	gzipContentHash := digest.FromBytes(gzipContent)
-	gzipDescriptor := ocispec.Descriptor{
-		MediaType: fmt.Sprintf("%s+gzip", ocispec.MediaTypeImageConfig),
-		Digest:    gzipContentHash,
-		Size:      int64(len(gzipContent)),
-	}
 
-	memStore := content.NewMemoryStore()
-	decompressStore := content.NewDecompressStore(memStore, content.WithBlocksize(0))
-	ctx := context.Background()
-	decompressWriter, err := decompressStore.Writer(ctx, ctrcontent.WithDescriptor(gzipDescriptor))
-	if err != nil {
-		t.Fatalf("unable to get a decompress writer: %v", err)
-	}
-	n, err := decompressWriter.Write(gzipContent)
-	if err != nil {
-		t.Fatalf("failed to write to decompress writer: %v", err)
-	}
-	if n != len(gzipContent) {
-		t.Fatalf("wrote %d instead of expected %d bytes", n, len(gzipContent))
-	}
-	if err := decompressWriter.Commit(ctx, int64(len(gzipContent)), gzipContentHash); err != nil {
-		t.Fatalf("unexpected error committing decompress writer: %v", err)
-	}
+	extensions := []string{"+gzip", ".gzip"}
+	for _, ext := range extensions {
+		gzipDescriptor := ocispec.Descriptor{
+			MediaType: fmt.Sprintf("%s%s", ocispec.MediaTypeImageConfig, ext),
+			Digest:    gzipContentHash,
+			Size:      int64(len(gzipContent)),
+		}
 
-	// and now we should be able to get the decompressed data from the memory store
-	_, b, found := memStore.Get(gzipDescriptor)
-	if !found {
-		t.Fatalf("failed to get data from underlying memory store: %v", err)
-	}
-	if string(b) != string(rawContent) {
-		t.Errorf("mismatched data in underlying memory store, actual '%s', expected '%s'", b, rawContent)
+		memStore := content.NewMemoryStore()
+		decompressStore := content.NewDecompressStore(memStore, content.WithBlocksize(0))
+		ctx := context.Background()
+		decompressWriter, err := decompressStore.Writer(ctx, ctrcontent.WithDescriptor(gzipDescriptor))
+		if err != nil {
+			t.Fatalf("unable to get a decompress writer: %v", err)
+		}
+		n, err := decompressWriter.Write(gzipContent)
+		if err != nil {
+			t.Fatalf("failed to write to decompress writer: %v", err)
+		}
+		if n != len(gzipContent) {
+			t.Fatalf("wrote %d instead of expected %d bytes", n, len(gzipContent))
+		}
+		if err := decompressWriter.Commit(ctx, int64(len(gzipContent)), gzipContentHash); err != nil {
+			t.Fatalf("unexpected error committing decompress writer: %v", err)
+		}
+
+		// and now we should be able to get the decompressed data from the memory store
+		_, b, found := memStore.Get(gzipDescriptor)
+		if !found {
+			t.Fatalf("failed to get data from underlying memory store: %v", err)
+		}
+		if string(b) != string(rawContent) {
+			t.Errorf("mismatched data in underlying memory store, actual '%s', expected '%s'", b, rawContent)
+		}
 	}
 }


### PR DESCRIPTION
I should have done this from the beginning. The decompress store treats `+gzip` as gzip and `.tar` as tar. This is correct, but there still its plenty out there that uses `.gzip`

This just handles that equally sanely. Adds it to the test as well, because we are well-behaved citizens. 😄 