### PR TITLE
filestore option to ignore noname error

### DIFF
--- a/pkg/content/file.go
+++ b/pkg/content/file.go
@@ -31,19 +31,28 @@ type FileStore struct {
 	// Reproducible enables stripping times from added files
 	Reproducible bool
 
-	root       string
-	descriptor *sync.Map // map[digest.Digest]ocispec.Descriptor
-	pathMap    *sync.Map
-	tmpFiles   *sync.Map
+	root         string
+	descriptor   *sync.Map // map[digest.Digest]ocispec.Descriptor
+	pathMap      *sync.Map
+	tmpFiles     *sync.Map
+	ignoreNoName bool
 }
 
 // NewFileStore creats a new file store
-func NewFileStore(rootPath string) *FileStore {
+func NewFileStore(rootPath string, opts ...WriterOpt) *FileStore {
+	// we have to process the opts to find if they told us to change defaults
+	var wOpts WriterOpts
+	for _, opt := range opts {
+		if err := opt(&wOpts); err != nil {
+			continue
+		}
+	}
 	return &FileStore{
-		root:       rootPath,
-		descriptor: &sync.Map{},
-		pathMap:    &sync.Map{},
-		tmpFiles:   &sync.Map{},
+		root:         rootPath,
+		descriptor:   &sync.Map{},
+		pathMap:      &sync.Map{},
+		tmpFiles:     &sync.Map{},
+		ignoreNoName: wOpts.IgnoreNoName,
 	}
 }
 
@@ -198,7 +207,14 @@ func (s *FileStore) Writer(ctx context.Context, opts ...content.WriterOpt) (cont
 
 	name, ok := ResolveName(desc)
 	if !ok {
-		return nil, ErrNoName
+		// if we were not told to ignore NoName, then return an error
+		if !s.ignoreNoName {
+			return nil, ErrNoName
+		}
+
+		// just return a nil writer - we do not want to calculate the hash, so just use
+		// whatever was passed in the descriptor
+		return NewIoContentWriter(ioutil.Discard, WithOutputHash(desc.Digest)), nil
 	}
 	path, err := s.resolveWritePath(name)
 	if err != nil {

--- a/pkg/content/file_test.go
+++ b/pkg/content/file_test.go
@@ -1,0 +1,45 @@
+package content_test
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	ctrcontent "github.com/containerd/containerd/content"
+	"github.com/deislabs/oras/pkg/content"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func TestFileStoreNoName(t *testing.T) {
+	testContent := []byte("Hello World!")
+	descriptor := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageConfig,
+		Digest:    digest.FromBytes(testContent),
+		Size:      int64(len(testContent)),
+		// do NOT add the AnnotationTitle here; it is the essence of the test
+	}
+
+	tests := []struct {
+		opts []content.WriterOpt
+		err  error
+	}{
+		{nil, content.ErrNoName},
+		{[]content.WriterOpt{content.WithIgnoreNoName()}, nil},
+	}
+	for _, tt := range tests {
+		rootPath, err := ioutil.TempDir("", "oras_filestore_test")
+		if err != nil {
+			t.Fatalf("error creating tempdir: %v", err)
+		}
+		defer os.RemoveAll(rootPath)
+		fileStore := content.NewFileStore(rootPath, tt.opts...)
+		ctx := context.Background()
+		refOpt := ctrcontent.WithDescriptor(descriptor)
+		if _, err := fileStore.Writer(ctx, refOpt); err != tt.err {
+			t.Errorf("mismatched error, actual '%v', expected '%v'", err, tt.err)
+		}
+
+	}
+}

--- a/pkg/content/opts.go
+++ b/pkg/content/opts.go
@@ -11,15 +11,17 @@ type WriterOpts struct {
 	OutputHash          *digest.Digest
 	Blocksize           int
 	MultiWriterIngester bool
+	IgnoreNoName        bool
 }
 
 type WriterOpt func(*WriterOpts) error
 
 func DefaultWriterOpts() WriterOpts {
 	return WriterOpts{
-		InputHash:  nil,
-		OutputHash: nil,
-		Blocksize:  DefaultBlocksize,
+		InputHash:    nil,
+		OutputHash:   nil,
+		Blocksize:    DefaultBlocksize,
+		IgnoreNoName: false,
 	}
 }
 
@@ -68,6 +70,16 @@ func WithBlocksize(blocksize int) WriterOpt {
 func WithMultiWriterIngester() WriterOpt {
 	return func(w *WriterOpts) error {
 		w.MultiWriterIngester = true
+		return nil
+	}
+}
+
+// WithIgnoreNoName some ingesters, when creating a Writer, return an error if
+// the descriptor does not have a valid name on the descriptor. Passing WithIgnoreNoName
+// tells the writer not to return an error, but rather to pass the data to a nil writer.
+func WithIgnoreNoName() WriterOpt {
+	return func(w *WriterOpts) error {
+		w.IgnoreNoName = true
 		return nil
 	}
 }


### PR DESCRIPTION
When we try to write to a FileStore (or more accurately, create a Writer from a FileStore), using a Descriptor that doesn't have a title annotation - `ocispec.AnnotationTitle` - then FileStore returns an `ErrNoName`.

This adds an option to ignore that error, i.e. if you pass it a descriptor without a name, `FileStore` will just ignore it, writing it to `ioutil.Discard`. This option allows one to blindly pass an entire OCI manifest and all of its dependencies to FileStore, which only will write down the ones it knows how to handle.

The default, of course, remains unchanged.

Also added a basic test.

As discussed with @jdolitsky in #230 