### PR TITLE
Build & release arm64 binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,10 @@ builds:
   - windows
   goarch:
   - amd64
+  - arm64
+  ignore:
+  - goos: windows
+    goarch: arm64
   ldflags:
   # one-line ldflags to bypass the goreleaser bugs
   # the git tree state is guaranteed to be clean by goreleaser
@@ -20,7 +24,7 @@ builds:
 archives:
   - format: tar.gz
     files:
-      - LICENSE
+    - LICENSE
 
 #signs:
 #  - artifacts: all

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -19,6 +19,12 @@ Mac:
 # builds to bin/darwin/amd64/oras
 make build-mac
 ```
+Mac ARM64:
+
+```bash
+# builds to bin/darwin/arm64/oras
+make build-mac-arm64
+```
 
 Linux:
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -65,9 +65,6 @@ git tag -a v0.1.0 -m "Release v0.1.0"
 git push origin v0.1.0
 ```
 
-A Codefresh pipeline will pick up the GitHub tag event
-and run [.codefresh/release.yml](.codefresh/release.yml).
-
-This will result in running [goreleaser](https://goreleaser.com/)
-to upload release artiacts, as well as push a tag to Docker Hub for
-the image `orasbot/oras`.
+A [GitHub Actions pipeline](.github/workflows) will pick up the GitHub tag
+event and run [goreleaser](https://goreleaser.com/) to upload release artiacts,
+as well as push a tag to Docker Hub for the image `orasbot/oras`.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -33,13 +33,12 @@ Linux:
 make build-linux
 ```
 
-Linux  ARM64:
+Linux ARM64:
 
 ```bash
-# builds to bin/linux/amd64/oras
-make build-linux
+# builds to bin/linux/arm64/oras
+make build-linux-arm64
 ```
-
 
 Windows:
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ clean:
 	git status --ignored --short | grep '^!! ' | sed 's/!! //' | xargs rm -rf
 
 .PHONY: build
-build: build-linux build-mac build-mac-arm64 build-windows
+build: build-linux build-linux-arm64 build-mac build-mac-arm64 build-windows
 
 .PHONY: build-linux
 build-linux:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GIT_COMMIT  = $(shell git rev-parse HEAD)
 GIT_TAG     = $(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null)
 GIT_DIRTY   = $(shell test -n "`git status --porcelain`" && echo "dirty" || echo "clean")
 
-TARGET_OBJS ?= checksums.txt darwin_amd64.tar.gz linux_amd64.tar.gz windows_amd64.tar.gz
+TARGET_OBJS ?= checksums.txt darwin_amd64.tar.gz darwin_arm64.tar.gz linux_amd64.tar.gz linux_arm64.tar.gz windows_amd64.tar.gz
 
 LDFLAGS = -w
 ifdef VERSION
@@ -30,7 +30,7 @@ clean:
 	git status --ignored --short | grep '^!! ' | sed 's/!! //' | xargs rm -rf
 
 .PHONY: build
-build: build-linux build-linux-arm64 build-mac build-windows
+build: build-linux build-mac build-mac-arm64 build-windows
 
 .PHONY: build-linux
 build-linux:
@@ -46,6 +46,11 @@ build-linux-arm64:
 build-mac:
 	GOARCH=amd64 CGO_ENABLED=0 GOOS=darwin go build -v --ldflags="$(LDFLAGS)" \
 		-o bin/darwin/amd64/$(CLI_EXE) $(CLI_PKG)
+
+.PHONY: build-mac-arm64
+build-mac-arm64:
+	GOARCH=arm64 CGO_ENABLED=0 GOOS=darwin go build -v --ldflags="$(LDFLAGS)" \
+		-o bin/darwin/arm64/$(CLI_EXE) $(CLI_PKG)
 
 .PHONY: build-windows
 build-windows:


### PR DESCRIPTION
This PR adds arm64 binaries for linux and darwin (Apple Silicon) to the release pipeline. Darwin arm64 is [supported as of golang 1.16](https://golang.org/doc/go1.16#darwin). Windows arm64, however, is not yet supported.

Additionally this updates a couple typos in the build docs.