### PR TITLE
fixing broken links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ ORAS is both a [CLI](#oras-cli) for initial testing and a [Go Module](#oras-go-m
 ## Table of Contents
 
 - [ORAS Background](#oras-background)
-- [Supported Registries](./implementors.md#registries-supporting-artifacts)
-- [Artifacts Implementing ORAS](./implementors.md#artifact-types-using-oras)
+- [Supported Registries](https://oras.land/implementors/#registries-supporting-artifacts)
+- [Artifacts Implementing ORAS](https://oras.land/implementors/#artifact-types-using-oras)
 - [Getting Started](#getting-started)
 - [ORAS CLI](#oras-cli)
 - [ORAS Go Module](#oras-go-module)
@@ -30,7 +30,7 @@ ORAS is both a [CLI](#oras-cli) for initial testing and a [Go Module](#oras-go-m
 
 ## Getting Started
 
-[Select from one the registries that support OCI Artifacts](./implementors.md). Each registry identifies how they support authentication.
+[Select from one the registries that support OCI Artifacts](https://oras.land/implementors/). Each registry identifies how they support authentication.
 
 ## ORAS CLI
 
@@ -104,7 +104,7 @@ Use the `-c`/`--config` option to specify an alternate location.
 oras pull -u username -p password myregistry.io/myimage:latest
 ```
 
-See [Supported Registries](./implementors.md) for registry specific authentication usage.
+See [Supported Registries](https://oras.land/implementors/) for registry specific authentication usage.
 
 ### Pushing Artifacts with Single Files
 


### PR DESCRIPTION
There are a few broken links to a previously existing implementors.md, and they should now link to the web-rendered docs. This will close #269.

And a naive question - if I want to implement a registry with custom artifact types, if oras serves as the client, is there a matching oci registry server in go that I can tweak to have custom artifacts/behavior, tweak the interface, etc.? I've never made a webby thing with go and thought it would be fun.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>