### PR TITLE
Enable CLI to Pull Config

### DIFF
--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/oras-project/oras-go/pkg/artifact"
 	"github.com/oras-project/oras-go/pkg/content"
 	ctxo "github.com/oras-project/oras-go/pkg/context"
 	"github.com/oras-project/oras-go/pkg/oras"
@@ -140,7 +141,7 @@ func runPull(opts pullOptions) error {
 }
 
 func appendPullManifestConfigHandlers(pullOpts []oras.PullOpt, manifestConfigRef string) []oras.PullOpt {
-	filename, mediaType := parseFileRef(manifestConfigRef, ocispec.MediaTypeImageConfig)
+	filename, mediaType := parseFileRef(manifestConfigRef, artifact.UnknownConfigMediaType)
 
 	var pullOnce sync.Once
 	marker := images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) (children []ocispec.Descriptor, err error) {

--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/oras-project/oras-go/pkg/content"
 	ctxo "github.com/oras-project/oras-go/pkg/context"
 	"github.com/oras-project/oras-go/pkg/oras"
 
+	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/reference"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -21,6 +24,7 @@ type pullOptions struct {
 	keepOldFiles       bool
 	pathTraversal      bool
 	output             string
+	manifestConfigRef  string
 	verbose            bool
 	cacheRoot          string
 
@@ -73,6 +77,7 @@ Example - Pull files with local cache:
 	cmd.Flags().BoolVarP(&opts.keepOldFiles, "keep-old-files", "k", false, "do not replace existing files when pulling, treat them as errors")
 	cmd.Flags().BoolVarP(&opts.pathTraversal, "allow-path-traversal", "T", false, "allow storing files out of the output directory")
 	cmd.Flags().StringVarP(&opts.output, "output", "o", "", "output directory")
+	cmd.Flags().StringVarP(&opts.manifestConfigRef, "manifest-config", "", "", "output manifest config file")
 	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", false, "verbose output")
 
 	cmd.Flags().BoolVarP(&opts.debug, "debug", "d", false, "debug mode")
@@ -114,6 +119,9 @@ func runPull(opts pullOptions) error {
 		}
 		pullOpts = append(pullOpts, oras.WithContentProvideIngester(cachedStore))
 	}
+	if opts.manifestConfigRef != "" {
+		pullOpts = appendPullManifestConfigHandlers(pullOpts, opts.manifestConfigRef)
+	}
 
 	desc, artifacts, err := oras.Pull(ctx, resolver, opts.targetRef, store, pullOpts...)
 	if err != nil {
@@ -129,4 +137,38 @@ func runPull(opts pullOptions) error {
 	fmt.Println("Digest:", desc.Digest)
 
 	return nil
+}
+
+func appendPullManifestConfigHandlers(pullOpts []oras.PullOpt, manifestConfigRef string) []oras.PullOpt {
+	filename, mediaType := parseFileRef(manifestConfigRef, ocispec.MediaTypeImageConfig)
+
+	var pullOnce sync.Once
+	marker := images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) (children []ocispec.Descriptor, err error) {
+		if desc.MediaType == mediaType {
+			pullOnce.Do(func() {
+				annotations := desc.Annotations
+				if annotations == nil {
+					annotations = make(map[string]string)
+				}
+				annotations[ocispec.AnnotationTitle] = filename
+				desc.Annotations = annotations
+				children = []ocispec.Descriptor{desc}
+			})
+		}
+		return
+	})
+	stopper := images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		if desc.MediaType == mediaType {
+			if name, _ := content.ResolveName(desc); name == "" {
+				return nil, images.ErrStopHandler
+			}
+		}
+		return nil, nil
+	})
+
+	return append(pullOpts,
+		oras.WithPullEmptyNameAllowed(),
+		oras.WithAllowedMediaType(mediaType),
+		oras.WithPullBaseHandler(marker, stopper),
+	)
 }

--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -147,9 +147,12 @@ func appendPullManifestConfigHandlers(pullOpts []oras.PullOpt, manifestConfigRef
 	marker := images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) (children []ocispec.Descriptor, err error) {
 		if desc.MediaType == mediaType {
 			pullOnce.Do(func() {
-				annotations := desc.Annotations
-				if annotations == nil {
-					annotations = make(map[string]string)
+				if desc.Annotations != nil {
+					delete(desc.Annotations, ocispec.AnnotationTitle)
+				}
+				annotations := make(map[string]string)
+				for k, v := range desc.Annotations {
+					annotations[k] = v
 				}
 				annotations[ocispec.AnnotationTitle] = filename
 				desc.Annotations = annotations


### PR DESCRIPTION
Add a new option named `--manifest-config` to `oras pull` so that `oras` can pull the config file as well even if the config is not named. Like `oras push`, file name with media type should be passed to the `--manifest-config` option. The media type is optional and its default value is `application/vnd.unknown.config.v1+json`. The resulted config will be written to the specified file name.

Examples:
```
$ oras pull --manifest-config config.json localhost:5000/hello:latest
Downloaded a948904f2f0f hi.txt
Downloaded 57f840b6073c config.json
Pulled localhost:5000/hello:latest
Digest: sha256:a5d8f401e10aa320bd7ecabbfbabb89b0e59e599c9fdc6587edbffaf232fa4f3
```

```
$ oras pull --manifest-config config.json:application/vnd.unknown.config.v1+json localhost:5000/hello:latest
Downloaded a948904f2f0f hi.txt
Downloaded 57f840b6073c config.json
Pulled localhost:5000/hello:latest
Digest: sha256:a5d8f401e10aa320bd7ecabbfbabb89b0e59e599c9fdc6587edbffaf232fa4f3
```